### PR TITLE
add nodes field

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -86,7 +86,7 @@ func TestNodes(t *testing.T) {
 
 	testCfg.AddNodeType(&NodeType{
 		Id:    nodeTypeId,
-		Name:  "TelemetryPacket",
+		Name:  "TestNode",
 		Model: reflect.TypeOf(node{}),
 		GetByIds: func(ctx context.Context, ids interface{}) (interface{}, error) {
 			var ret []*node

--- a/api_test.go
+++ b/api_test.go
@@ -1,9 +1,12 @@
 package apifu
 
 import (
+	"context"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -13,11 +16,20 @@ import (
 	"github.com/ccbrown/api-fu/graphql"
 )
 
-var testCfg = Config{}
+func executeGraphQL(t *testing.T, api *API, query string) *http.Response {
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("POST", "", strings.NewReader(query))
+	r.Header.Set("Content-Type", "application/graphql")
+	require.NoError(t, err)
+	api.ServeGraphQL(w, r)
+	return w.Result()
+}
 
-var asyncChannel = make(chan struct{})
+func TestGo(t *testing.T) {
+	var asyncChannel = make(chan struct{})
 
-func init() {
+	var testCfg Config
+
 	// If this is not executed asynchronously alongside a matching asyncReceiver, it will deadlock.
 	testCfg.AddQueryField("asyncSender", &graphql.FieldDefinition{
 		Type: graphql.BooleanType,
@@ -39,18 +51,7 @@ func init() {
 			}), nil
 		},
 	})
-}
 
-func executeGraphQL(t *testing.T, api *API, query string) *http.Response {
-	w := httptest.NewRecorder()
-	r, err := http.NewRequest("POST", "", strings.NewReader(query))
-	r.Header.Set("Content-Type", "application/graphql")
-	require.NoError(t, err)
-	api.ServeGraphQL(w, r)
-	return w.Result()
-}
-
-func TestGo(t *testing.T) {
 	api, err := NewAPI(&testCfg)
 	require.NoError(t, err)
 
@@ -64,4 +65,64 @@ func TestGo(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"data":{"s":true,"r":true}}`, string(body))
+}
+
+func TestNodes(t *testing.T) {
+	const nodeTypeId = 10
+
+	testCfg := Config{
+		SerializeNodeId: func(typeId int, id interface{}) string {
+			assert.Equal(t, nodeTypeId, typeId)
+			return id.(string)
+		},
+		DeserializeNodeId: func(id string) (int, interface{}) {
+			return nodeTypeId, id
+		},
+	}
+
+	type node struct {
+		Id string
+	}
+
+	testCfg.AddNodeType(&NodeType{
+		Id:    nodeTypeId,
+		Name:  "TelemetryPacket",
+		Model: reflect.TypeOf(node{}),
+		GetByIds: func(ctx context.Context, ids interface{}) (interface{}, error) {
+			var ret []*node
+			for _, id := range ids.([]string) {
+				if id == "a" || id == "b" {
+					ret = append(ret, &node{
+						Id: id,
+					})
+				}
+			}
+			return ret, nil
+		},
+		Fields: map[string]*graphql.FieldDefinition{
+			"id": OwnID("Id"),
+		},
+	})
+
+	api, err := NewAPI(&testCfg)
+	require.NoError(t, err)
+
+	resp := executeGraphQL(t, api, `{
+		nodes(ids: ["a", "b", "c", "d"]) {
+			id
+		}
+	}`)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result struct {
+		Data struct {
+			Nodes []node
+		}
+		Errors []struct{}
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Empty(t, result.Errors)
+
+	assert.ElementsMatch(t, []node{node{Id: "a"}, node{Id: "b"}}, result.Data.Nodes)
 }

--- a/config.go
+++ b/config.go
@@ -62,6 +62,22 @@ func (cfg *Config) init() {
 						return ctxAPI(ctx.Context).resolveNodeByGlobalId(ctx.Context, ctx.Arguments["id"].(string))
 					},
 				},
+				"nodes": &graphql.FieldDefinition{
+					Type:        graphql.NewListType(cfg.nodeInterface),
+					Description: "Gets nodes for multiple ids. Non-existent nodes are not returned and the order of the returned nodes is arbitrary, so clients should check the ids of the returned nodes.",
+					Arguments: map[string]*graphql.InputValueDefinition{
+						"ids": &graphql.InputValueDefinition{
+							Type: graphql.NewNonNullType(graphql.NewListType(graphql.NewNonNullType(graphql.IDType))),
+						},
+					},
+					Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+						var ids []string
+						for _, id := range ctx.Arguments["ids"].([]interface{}) {
+							ids = append(ids, id.(string))
+						}
+						return ctxAPI(ctx.Context).resolveNodesByGlobalIds(ctx.Context, ids)
+					},
+				},
 			},
 		}
 	})


### PR DESCRIPTION
## What it Does

Adds the `nodes` field to Query. This makes it possible for clients to get multiple nodes without constructing queries at runtime, enabling compile-time validation for queries in these use-cases.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
