### PR TITLE
runtime typename checking for gql-client-gen fragments

### DIFF
--- a/cmd/gql-client-gen/README.md
+++ b/cmd/gql-client-gen/README.md
@@ -53,7 +53,7 @@ println(gql(`query User {
 }`))
 ```
 
-Will generate something like...:
+Will generate something like...
 
 ```go
 type selNode0 struct {

--- a/cmd/gql-client-gen/README.md
+++ b/cmd/gql-client-gen/README.md
@@ -18,26 +18,6 @@ func main() {
 		}
 	  }
 	}`))
-
-	println(gql(`mutation AddReactionToIssue {
-	  addReaction(input:{subjectId:"MDU6SXNzdWUyMzEzOTE1NTE=",content:HOORAY}) {
-		reaction {
-		  content
-		}
-		subject {
-		  id
-		}
-	  }
-	}`))
-
-	println(gql(`query User {
-	  node(id:"MDQ6VXNlcjU4MzIzMQ==") {
-	   ... on User {
-		  name
-		  login
-		}
-	  }
-	}`))
 }
 ```
 
@@ -53,39 +33,61 @@ type FindIssueIDData struct {
 		}
 	}
 }
-
-type ReactionContent string
-
-const (
-	ReactionContentHooray     ReactionContent = "HOORAY"
-	ReactionContentConfused   ReactionContent = "CONFUSED"
-	ReactionContentHeart      ReactionContent = "HEART"
-	ReactionContentRocket     ReactionContent = "ROCKET"
-	ReactionContentEyes       ReactionContent = "EYES"
-	ReactionContentThumbsUp   ReactionContent = "THUMBS_UP"
-	ReactionContentThumbsDown ReactionContent = "THUMBS_DOWN"
-	ReactionContentLaugh      ReactionContent = "LAUGH"
-)
-
-type AddReactionToIssueData struct {
-	AddReaction *struct {
-		Reaction *struct {
-			Content ReactionContent
-		}
-		Subject *struct {
-			Id string
-		}
-	}
-}
-
-type UserData struct {
-	Node *struct {
-		User *struct {
-			Name  *string
-			Login string
-		}
-	}
-}
 ```
 
 It will generate types for all named queries and mutations as well as all named fragments.
+
+## Inline Fragments and Fragment Spreads
+
+Types can also be generated for queries that involve fragments with type conditions. In these cases, your queries must select `__typename` so the generated types can know which spreads to unmarshal. For example:
+
+```go
+println(gql(`query User {
+  node(id:"MDQ6VXNlcjU4MzIzMQ==") {
+   __typename
+   ... on User {
+      name
+      login
+    }
+  }
+}`))
+```
+
+Will generate something like...:
+
+```go
+type selNode0 struct {
+	Typename__ string `json:"__typename"`
+	User       *struct {
+		Name  *string
+		Login string
+	} `json:"-"`
+}
+
+func (s *selNode0) UnmarshalJSON(b []byte) error {
+	var base struct {
+		Typename__ string `json:"__typename"`
+		User       *struct {
+			Name  *string
+			Login string
+		} `json:"-"`
+	}
+	if err := json.Unmarshal(b, &base); err != nil {
+		return err
+	}
+	*s = base
+	switch base.Typename__ {
+	case "User":
+		if err := json.Unmarshal(b, &s.User); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type UserData struct {
+	Node *selNode0
+}
+```
+
+After unmarshaling, `UserData.Node.User` will be nil or non-nil depending on the type of the node returned.

--- a/cmd/gql-client-gen/testdata/github.go
+++ b/cmd/gql-client-gen/testdata/github.go
@@ -23,6 +23,7 @@ func main() {
 
 	println(gql(`query User {
 	  node(id:"MDQ6VXNlcjU4MzIzMQ==") {
+	   __typename
 	   ... on User {
 		  name
 		  login

--- a/pagination.go
+++ b/pagination.go
@@ -213,7 +213,7 @@ func Connection(config *ConnectionConfig) *graphql.FieldDefinition {
 			if first, ok := ctx.Arguments["first"].(int); ok {
 				if first < 0 {
 					return nil, fmt.Errorf("The `first` argument cannot be negative.")
-				} else if _, ok := ctx.Arguments["last"]; ok {
+				} else if _, ok := ctx.Arguments["last"].(int); ok {
 					return nil, fmt.Errorf("You cannot provide both `first` and `last` arguments.")
 				}
 			} else if last, ok := ctx.Arguments["last"].(int); ok {


### PR DESCRIPTION
## What it Does

This checks __typename for type info when unmarshaling structures with fragment spreads or inline fragments.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
