### PR TITLE
more jsoniter for more speed

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,12 +2,12 @@ package apifu
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"reflect"
 	"strconv"
 	"sync"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -143,7 +143,7 @@ func (api *API) ServeGraphQL(w http.ResponseWriter, r *http.Request) {
 	req.Schema = api.schema
 	req.IdleHandler = apiRequest.IdleHandler
 
-	body, err := json.Marshal(graphql.Execute(req))
+	body, err := jsoniter.Marshal(graphql.Execute(req))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/graphql/executor/ordered_map_test.go
+++ b/graphql/executor/ordered_map_test.go
@@ -1,0 +1,45 @@
+package executor
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderedMapEncoding(t *testing.T) {
+	m := NewOrderedMap()
+	m.Set("foo", "bar")
+	m.Set("foo2", "bar2")
+	buf, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"foo":"bar","foo2":"bar2"}`, string(buf))
+}
+
+var sink interface{}
+
+func BenchmarkOrderedMapEncoding(b *testing.B) {
+	m := NewOrderedMap()
+	for i := 0; i < 2000; i++ {
+		m.Set("foo"+strconv.Itoa(i), "bar")
+		m2 := NewOrderedMap()
+		for j := 0; j < 10; j++ {
+			m2.Set("foo"+strconv.Itoa(j), "bar")
+			m3 := NewOrderedMap()
+			for k := 0; k < 10; k++ {
+				m3.Set("foo"+strconv.Itoa(k), "bar")
+			}
+			m2.Set("m"+strconv.Itoa(j), m3)
+		}
+		m.Set("m"+strconv.Itoa(i), m2)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sink, _ = jsoniter.ConfigFastest.Marshal(m)
+	}
+}


### PR DESCRIPTION
## What it Does

Uses custom jsoniter encoder for significantly improved result marshaling speed.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
