### PR TITLE
halve allocations

### DIFF
--- a/graphql/executor/path.go
+++ b/graphql/executor/path.go
@@ -1,14 +1,22 @@
 package executor
 
 type path struct {
-	Prev      *path
-	Component interface{}
+	Prev            *path
+	StringComponent string
+	IntComponent    int
 }
 
-func (p *path) WithComponent(component interface{}) *path {
+func (p *path) WithIntComponent(n int) *path {
 	return &path{
-		Prev:      p,
-		Component: component,
+		Prev:         p,
+		IntComponent: n,
+	}
+}
+
+func (p *path) WithStringComponent(s string) *path {
+	return &path{
+		Prev:            p,
+		StringComponent: s,
 	}
 }
 
@@ -16,5 +24,8 @@ func (p *path) Slice() []interface{} {
 	if p == nil {
 		return nil
 	}
-	return append(p.Prev.Slice(), p.Component)
+	if p.StringComponent != "" {
+		return append(p.Prev.Slice(), p.StringComponent)
+	}
+	return append(p.Prev.Slice(), p.IntComponent)
 }

--- a/graphql/schema/builtins.go
+++ b/graphql/schema/builtins.go
@@ -124,7 +124,7 @@ var FloatType = &ScalarType{
 }
 
 func coerceString(v interface{}) interface{} {
-	switch v := v.(type) {
+	switch v.(type) {
 	case string:
 		return v
 	}


### PR DESCRIPTION
## What it Does

* Eliminates excessive closure / future generation for nullable error catching
* Eliminates `interface{}` usage in path construction
* Eliminates argument map allocation for fields with no arguments
* Reduces closure allocation in future functions
* Eliminates `interface{}` allocation in string coercion

Altogether this more than halves allocations.

Before:

```
chris@mbp18 executor % go test . -run asdqwe -bench BenchmarkExecuteRequest
goos: darwin
goarch: amd64
pkg: github.com/ccbrown/api-fu/graphql/executor
BenchmarkExecuteRequest-12    	     607	   1960918 ns/op	 1415254 B/op	   42777 allocs/op
PASS
ok  	github.com/ccbrown/api-fu/graphql/executor	1.516s
go test . -run asdqwe -bench BenchmarkExecuteRequest  2.73s user 0.62s system 161% cpu 2.074 total
```

After:

```
chris@mbp18 executor % go test . -run asdqwe -bench BenchmarkExecuteRequest
goos: darwin
goarch: amd64
pkg: github.com/ccbrown/api-fu/graphql/executor
BenchmarkExecuteRequest-12    	    1017	   1175525 ns/op	  813230 B/op	   20465 allocs/op
PASS
ok  	github.com/ccbrown/api-fu/graphql/executor	1.409s
go test . -run asdqwe -bench BenchmarkExecuteRequest  2.48s user 0.63s system 157% cpu 1.973 total
```

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
