### PR TITLE
fix unreferenced iface implementations in schema definitions built from introspection

### DIFF
--- a/graphql/schema/introspection/schema_data.go
+++ b/graphql/schema/introspection/schema_data.go
@@ -107,6 +107,9 @@ func (d *SchemaData) GetSchemaDefinition() (*schema.SchemaDefinition, error) {
 					def.ImplementedInterfaces = append(def.ImplementedInterfaces, iface)
 				}
 			}
+			if len(t.Interfaces) > 0 {
+				ret.AdditionalTypes = append(ret.AdditionalTypes, def)
+			}
 			def.IsTypeOf = func(v interface{}) bool {
 				return false
 			}

--- a/graphql/schema/introspection/schema_data_test.go
+++ b/graphql/schema/introspection/schema_data_test.go
@@ -59,4 +59,18 @@ func TestSchemaData(t *testing.T) {
 		_, errs := graphql.ParseAndValidate(query, schema)
 		assert.NotEmpty(t, errs)
 	})
+
+	t.Run("UnreferencedInterface", func(t *testing.T) {
+		query := `{
+				node(id: "foo") {
+					... on RepositoryInvitation {
+						id
+					}
+				}
+			}
+		`
+
+		_, errs := graphql.ParseAndValidate(query, schema)
+		assert.Empty(t, errs)
+	})
 }


### PR DESCRIPTION
## What it Does

@crhanlon Fixes the bug you mentioned and adds a test.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
