### PR TITLE
Optional execute hook

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,6 +18,11 @@ type Config struct {
 	DeserializeNodeId    func(string) (typeId int, id interface{})
 	AdditionalNodeFields map[string]*graphql.FieldDefinition
 
+	// Execute is invoked to execute a GraphQL request. If not given, this is simply
+	// graphql.Execute. You may wish to provide this to perform request logging or
+	// pre/post-processing.
+	Execute func(*graphql.Request) *graphql.Response
+
 	initOnce              sync.Once
 	nodeObjectTypesByName map[string]*graphql.ObjectType
 	nodeTypesByModel      map[reflect.Type]*NodeType

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -51,7 +51,7 @@ func ExecuteRequest(ctx context.Context, r *Request) (*OrderedMap, []*Error) {
 
 // IsSubscription can be used to determine if a request is for a subscription.
 func IsSubscription(doc *ast.Document, operationName string) bool {
-	operation, err := getOperation(doc, operationName)
+	operation, err := GetOperation(doc, operationName)
 	return err == nil && operation.OperationType != nil && operation.OperationType.Value == "subscription"
 }
 
@@ -84,7 +84,7 @@ type executor struct {
 }
 
 func newExecutor(ctx context.Context, r *Request) (*executor, *Error) {
-	operation, err := getOperation(r.Document, r.OperationName)
+	operation, err := GetOperation(r.Document, r.OperationName)
 	if err != nil {
 		return nil, err
 	}
@@ -515,7 +515,10 @@ func doesFragmentTypeApply(objectType *schema.ObjectType, fragmentType schema.Ty
 	panic(fmt.Sprintf("unexpected fragment type: %T", fragmentType))
 }
 
-func getOperation(doc *ast.Document, operationName string) (*ast.OperationDefinition, *Error) {
+// GetOperation returns the operation selected by the given name. If operationName is "" and the
+// document contains only one operation, it is returned. Otherwise the document must contain exactly
+// one operation with the given name.
+func GetOperation(doc *ast.Document, operationName string) (*ast.OperationDefinition, *Error) {
 	var ret *ast.OperationDefinition
 	for _, def := range doc.Definitions {
 		if def, ok := def.(*ast.OperationDefinition); ok {

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -465,21 +465,21 @@ func TestGetOperation(t *testing.T) {
 	doc, errs := parser.ParseDocument([]byte(`{x} {x} query q {x} mutation m {x} mutation m {x}`))
 	assert.Empty(t, errs)
 
-	_, err := getOperation(doc, "")
+	_, err := GetOperation(doc, "")
 	assert.NotNil(t, err)
 
-	op, err := getOperation(doc, "m")
+	op, err := GetOperation(doc, "m")
 	assert.Nil(t, op)
 	assert.NotNil(t, err)
 
-	op, err = getOperation(doc, "q")
+	op, err = GetOperation(doc, "q")
 	assert.NotNil(t, op)
 	assert.Nil(t, err)
 
 	doc, errs = parser.ParseDocument([]byte(`query q {x}`))
 	assert.Empty(t, errs)
 
-	op, err = getOperation(doc, "")
+	op, err = GetOperation(doc, "")
 	assert.NotNil(t, op)
 	assert.Nil(t, err)
 }

--- a/graphqlws.go
+++ b/graphqlws.go
@@ -63,7 +63,7 @@ func (h *graphqlWSHandler) HandleStart(id string, query string, variables map[st
 					if err := sourceStream.Run(context.Background(), func(event interface{}) {
 						req := *req
 						req.InitialValue = event
-						if err := h.Connection.SendData(id, graphql.Execute(&req)); err != nil {
+						if err := h.Connection.SendData(id, h.API.execute(&req)); err != nil {
 							h.Connection.Logger.Warn(errors.Wrap(err, "error sending graphql-ws data"))
 						}
 					}); err != nil && err != context.Canceled {
@@ -72,7 +72,7 @@ func (h *graphqlWSHandler) HandleStart(id string, query string, variables map[st
 				}()
 			}
 		} else {
-			resp = graphql.Execute(req)
+			resp = h.API.execute(req)
 		}
 	}
 


### PR DESCRIPTION
## What it Does

Adds the ability to wrap the actual graphql.Execute invocation for the purposes of logging or pre/post-processing. Also makes GetOperation public, which is useful e.g. to log the query's actual operation name.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
