### PR TITLE
add mechanism for handling graphql-ws connection init parameters

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,8 @@
 package apifu
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"sync"
@@ -26,6 +28,13 @@ type Config struct {
 	// graphql.Execute. You may wish to provide this to perform request logging or
 	// pre/post-processing.
 	Execute func(*graphql.Request) *graphql.Response
+
+	// If given, this function is invoked when the servers receives the graphql-ws connection init
+	// payload. If an error is returned, it will be sent to the client and the connection will be
+	// closed. Otherwise the returned context will become associated with the connection.
+	//
+	// This is commonly used for authentication.
+	HandleGraphQLWSInit func(ctx context.Context, parameters json.RawMessage) (context.Context, error)
 
 	initOnce              sync.Once
 	nodeObjectTypesByName map[string]*graphql.ObjectType

--- a/graphqlws.go
+++ b/graphqlws.go
@@ -2,6 +2,7 @@ package apifu
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/gorilla/websocket"
@@ -17,6 +18,17 @@ type graphqlWSHandler struct {
 	Context    context.Context
 
 	subscriptions map[string]*SubscriptionSourceStream
+}
+
+func (h *graphqlWSHandler) HandleInit(parameters json.RawMessage) error {
+	if f := h.API.config.HandleGraphQLWSInit; f != nil {
+		if ctx, err := f(h.Context, parameters); err != nil {
+			return err
+		} else {
+			h.Context = ctx
+		}
+	}
+	return nil
 }
 
 func (h *graphqlWSHandler) HandleStart(id string, query string, variables map[string]interface{}, operationName string) {

--- a/graphqlws/graphqlws.go
+++ b/graphqlws/graphqlws.go
@@ -10,6 +10,7 @@ type MessageType string
 // MessageType represents a GraphQL-WS message type.
 const (
 	MessageTypeConnectionInit      MessageType = "connection_init"
+	MessageTypeConnectionError     MessageType = "connection_error"
 	MessageTypeConnectionKeepAlive MessageType = "ka"
 	MessageTypeConnectionTerminate MessageType = "connection_terminate"
 	MessageTypeConnectionAck       MessageType = "connection_ack"

--- a/graphqlws_test.go
+++ b/graphqlws_test.go
@@ -1,6 +1,8 @@
 package apifu
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -131,4 +133,113 @@ func TestGraphQLWS(t *testing.T) {
 		assert.Equal(t, "sub", msg.Id)
 		assert.Equal(t, graphqlws.MessageTypeComplete, msg.Type)
 	})
+}
+
+func TestGraphQLWS_InitParameters(t *testing.T) {
+	var testCfg Config
+
+	testCfg.AddQueryField("whoami", &graphql.FieldDefinition{
+		Type: graphql.StringType,
+		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+			return ctx.Context.Value("name"), nil
+		},
+	})
+
+	testCfg.HandleGraphQLWSInit = func(ctx context.Context, parameters json.RawMessage) (context.Context, error) {
+		var params struct {
+			Name string
+		}
+		if err := json.Unmarshal(parameters, &params); err != nil {
+			return ctx, err
+		} else if params.Name == "" {
+			return ctx, fmt.Errorf("no name")
+		}
+		ctx = context.WithValue(ctx, "name", params.Name)
+		return ctx, nil
+	}
+
+	api, err := NewAPI(&testCfg)
+	require.NoError(t, err)
+	defer api.CloseHijackedConnections()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		api.ServeGraphQLWS(w, r)
+	}))
+	defer ts.Close()
+
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: time.Second,
+		Subprotocols:     []string{"graphql-ws"},
+	}
+
+	for name, tc := range map[string]struct {
+		Parameters    json.RawMessage
+		ExpectedName  string
+		ExpectedError string
+	}{
+		"Ok": {
+			ExpectedName: "alice",
+			Parameters:   json.RawMessage(`{"name": "alice"}`),
+		},
+		"NoName": {
+			ExpectedError: "no name",
+			Parameters:    json.RawMessage(`{"foo": "bar"}`),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var conn *websocket.Conn
+			for attempts := 0; attempts < 100; attempts++ {
+				clientConn, _, err := dialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+				if err != nil {
+					time.Sleep(time.Millisecond * 10)
+				} else {
+					conn = clientConn
+					break
+				}
+			}
+			require.NotNil(t, conn)
+			defer conn.Close()
+
+			require.NoError(t, conn.WriteJSON(map[string]interface{}{
+				"id":      "init",
+				"type":    "connection_init",
+				"payload": tc.Parameters,
+			}))
+
+			var msg graphqlws.Message
+
+			if tc.ExpectedError != "" {
+				require.NoError(t, conn.ReadJSON(&msg))
+				assert.Equal(t, graphqlws.MessageTypeConnectionError, msg.Type)
+				assert.JSONEq(t, fmt.Sprintf(`{"message": %#v}`, tc.ExpectedError), string(msg.Payload))
+			} else {
+				require.NoError(t, conn.ReadJSON(&msg))
+				assert.Equal(t, graphqlws.MessageTypeConnectionAck, msg.Type)
+
+				require.NoError(t, conn.ReadJSON(&msg))
+				assert.Equal(t, graphqlws.MessageTypeConnectionKeepAlive, msg.Type)
+
+				require.NoError(t, conn.WriteJSON(map[string]interface{}{
+					"id":   "query",
+					"type": "start",
+					"payload": map[string]interface{}{
+						"query": `
+					{
+						whoami
+					}
+				`,
+					},
+				}))
+
+				require.NoError(t, conn.ReadJSON(&msg))
+				assert.Equal(t, "query", msg.Id)
+				assert.Equal(t, graphqlws.MessageTypeData, msg.Type)
+				assert.JSONEq(t, fmt.Sprintf(`{"data": {"whoami": %#v}}`, tc.ExpectedName), string(msg.Payload))
+
+				require.NoError(t, conn.ReadJSON(&msg))
+				assert.Equal(t, "query", msg.Id)
+				assert.Equal(t, graphqlws.MessageTypeComplete, msg.Type)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What it Does

Add a mechanism for handling graphql-ws connection init parameters.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
