### PR TITLE
Fix subscribe returning the wrong resolve error

### DIFF
--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -180,7 +180,7 @@ func (e *executor) subscribe(initialValue interface{}) (interface{}, *Error) {
 	})
 	if !isNil(resolveErr) {
 		return nil, &Error{
-			Message: err.Error(),
+			Message: resolveErr.Error(),
 			Locations: []Location{{
 				Line:   field.Position().Line,
 				Column: field.Position().Column,


### PR DESCRIPTION
## What it Does

Return `fieldDef.Resolve` error instead of `coerceArgumentValues` error

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
