### PR TITLE
fix scanning for terminating comments

### DIFF
--- a/graphql/scanner/scanner.go
+++ b/graphql/scanner/scanner.go
@@ -147,7 +147,7 @@ func (s *Scanner) Scan() bool {
 			}
 			s.token = token.LINE_TERMINATOR
 		case '#':
-			for s.nextRune != '\r' && s.nextRune != '\n' {
+			for !s.isDone() && s.nextRune != '\r' && s.nextRune != '\n' {
 				s.consumeRune()
 			}
 			s.token = token.COMMENT

--- a/graphql/scanner/scanner_test.go
+++ b/graphql/scanner/scanner_test.go
@@ -219,3 +219,22 @@ func TestScanner_SkipsIgnored(t *testing.T) {
 	assert.Equal(t, []string{"{", "node", "{", "}", "}"}, literals)
 	assert.Empty(t, s.Errors())
 }
+
+// This is a regression test for an issue where the scanner would go into an infinite loop if the
+// input ended with a comment.
+func TestScanner_TerminatingComment(t *testing.T) {
+	s := New([]byte("{ foo } # bar"), 0)
+	var tokens []token.Token
+	var literals []string
+	for s.Scan() {
+		tokens = append(tokens, s.Token())
+		literals = append(literals, s.Literal())
+	}
+	assert.Equal(t, []token.Token{
+		token.PUNCTUATOR,
+		token.NAME,
+		token.PUNCTUATOR,
+	}, tokens)
+	assert.Equal(t, []string{"{", "foo", "}"}, literals)
+	assert.Empty(t, s.Errors())
+}


### PR DESCRIPTION
## What it Does

Fixes a scanner bug when the input ended in a comment.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
