### PR TITLE
add support for newer graphql-transport-ws subscription subprotocol

### DIFF
--- a/api.go
+++ b/api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/ccbrown/api-fu/graphql"
-	"github.com/ccbrown/api-fu/graphqlws"
 )
 
 // API is responsible for serving your API traffic. Construct an API by creating a Config, then
@@ -24,7 +23,7 @@ type API struct {
 	execute func(*graphql.Request, *RequestInfo) *graphql.Response
 
 	graphqlWSConnectionsMutex sync.Mutex
-	graphqlWSConnections      map[*graphqlws.Connection]struct{}
+	graphqlWSConnections      map[graphqlWSConnection]struct{}
 }
 
 func (api *API) Schema() *graphql.Schema {
@@ -63,7 +62,7 @@ func NewAPI(cfg *Config) (*API, error) {
 		schema:               schema,
 		logger:               logger,
 		execute:              execute,
-		graphqlWSConnections: map[*graphqlws.Connection]struct{}{},
+		graphqlWSConnections: map[graphqlWSConnection]struct{}{},
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/graphql/transport/graphqltransportws/README.md
+++ b/graphql/transport/graphqltransportws/README.md
@@ -1,0 +1,3 @@
+# graphqltransportws
+
+This is the implementation of the "graphql-transport-ws" protocol defined by [enisdenjo/graphql-ws](https://github.com/enisdenjo/graphql-ws).

--- a/graphql/transport/graphqltransportws/connection.go
+++ b/graphql/transport/graphqltransportws/connection.go
@@ -1,0 +1,300 @@
+package graphqltransportws
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/ccbrown/api-fu/graphql"
+	"github.com/gorilla/websocket"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+// Connection represents a server-side GraphQL-WS connection.
+type Connection struct {
+	Handler ConnectionHandler
+
+	conn              *websocket.Conn
+	readLoopDone      chan struct{}
+	writeLoopDone     chan struct{}
+	outgoing          chan *websocket.PreparedMessage
+	close             chan struct{}
+	closeReceived     chan struct{}
+	closeMessage      chan []byte
+	beginClosingOnce  sync.Once
+	finishClosingOnce sync.Once
+	didInit           bool
+}
+
+// ConnectionHandler methods may be invoked on a separate goroutine, but invocations will never be
+// made concurrently.
+type ConnectionHandler interface {
+	// Called when the server receives the init message. If an error is returned, it will be sent to
+	// the client and the connection will be closed.
+	HandleInit(parameters json.RawMessage) error
+
+	// Called when the client wants to start an operation. If the operation is a query or mutation,
+	// the handler should immediately call SendData followed by SendComplete. If the operation is a
+	// subscription, the handler should call SendData to send events and SendComplete if/when the
+	// event stream ends.
+	HandleStart(id string, query string, variables map[string]interface{}, operationName string)
+
+	// Called when the client wants to stop an operation. The handler should unsubscribe them from
+	// the corresponding subscription.
+	HandleStop(id string)
+
+	// Called when an unexpected error occurs. The connection will perform the appropriate response,
+	// but you may want to log it.
+	LogError(err error)
+
+	// Called when the connection begins closing and all in-flight operations should be canceled.
+	Cancel()
+
+	// Called when the connection is closed.
+	HandleClose()
+}
+
+const connectionSendBufferSize = 100
+
+// Serve takes ownership of the given connection and begins reading / writing to it.
+func (c *Connection) Serve(conn *websocket.Conn) {
+	c.conn = conn
+	c.readLoopDone = make(chan struct{})
+	c.writeLoopDone = make(chan struct{})
+	c.outgoing = make(chan *websocket.PreparedMessage, connectionSendBufferSize)
+	c.close = make(chan struct{})
+	c.closeReceived = make(chan struct{})
+	c.closeMessage = make(chan []byte, 1)
+	conn.SetCloseHandler(func(code int, text string) error {
+		select {
+		case <-c.closeReceived:
+		default:
+			close(c.closeReceived)
+		}
+		return nil
+	})
+	go c.readLoop()
+	go c.writeLoop()
+}
+
+// SendData sends the given GraphQL response to the client.
+func (c *Connection) SendData(ctx context.Context, id string, response *graphql.Response) error {
+	buf, err := jsoniter.Marshal(response)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal graphql response")
+	}
+	return c.sendMessage(ctx, &Message{
+		Id:      id,
+		Type:    MessageTypeNext,
+		Payload: json.RawMessage(buf),
+	})
+}
+
+// SendComplete sends the "complete" message to the client. This should be done after queries are
+// executed or subscriptions are stopped.
+func (c *Connection) SendComplete(ctx context.Context, id string) error {
+	return c.sendMessage(ctx, &Message{
+		Id:   id,
+		Type: MessageTypeComplete,
+	})
+}
+
+// Close closes the connection. This must not be called from handler functions.
+func (c *Connection) Close() error {
+	c.beginClosing(websocket.CloseNormalClosure, "close requested by application")
+	c.finishClosing()
+	return nil
+}
+
+func (c *Connection) sendMessage(ctx context.Context, msg *Message) error {
+	data, err := jsoniter.Marshal(msg)
+	if err != nil {
+		return errors.Wrap(err, "error marshaling message")
+	}
+	prepared, err := websocket.NewPreparedMessage(websocket.TextMessage, data)
+	if err != nil {
+		return errors.Wrap(err, "error preparing message")
+	}
+	select {
+	case c.outgoing <- prepared:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (c *Connection) readLoop() {
+	defer close(c.readLoopDone)
+	defer c.beginClosing(websocket.CloseInternalServerErr, "read error")
+
+	for {
+		_, p, err := c.conn.ReadMessage()
+		if err != nil {
+			if _, ok := err.(*websocket.CloseError); !ok {
+				select {
+				case <-c.close:
+				default:
+					c.Handler.LogError(errors.Wrap(err, "websocket read error"))
+				}
+			}
+			return
+		}
+
+		c.handleMessage(context.Background(), p)
+	}
+}
+
+func (c *Connection) handleMessage(ctx context.Context, data []byte) {
+	var msg Message
+	if err := json.Unmarshal(data, &msg); err != nil {
+		c.beginClosing(4400, "unable to deserialize message")
+		return
+	}
+
+	switch msg.Type {
+	case MessageTypeConnectionInit:
+		if err := c.Handler.HandleInit(msg.Payload); err != nil {
+			c.beginClosing(4403, err.Error())
+			return
+		}
+
+		c.didInit = true
+		if err := c.sendMessage(ctx, &Message{
+			Type: MessageTypeConnectionAck,
+		}); err != nil {
+			c.Handler.LogError(errors.Wrap(err, "unable to send graphql-ws connection ack"))
+			c.beginClosing(websocket.CloseInternalServerErr, "ack send error")
+		}
+	case MessageTypeSubscribe:
+		if !c.didInit {
+			return
+		}
+
+		var payload struct {
+			Query         string                 `json:"query"`
+			Variables     map[string]interface{} `json:"variables"`
+			OperationName string                 `json:"operationName"`
+		}
+		if err := jsoniter.Unmarshal(msg.Payload, &payload); err != nil {
+			c.beginClosing(4400, "unable to deserialize payload")
+			return
+		}
+		c.Handler.HandleStart(msg.Id, payload.Query, payload.Variables, payload.OperationName)
+	case MessageTypeComplete:
+		if !c.didInit {
+			return
+		}
+
+		c.Handler.HandleStop(msg.Id)
+		if err := c.sendMessage(context.Background(), &Message{
+			Id:   msg.Id,
+			Type: MessageTypeComplete,
+		}); err != nil {
+			c.Handler.LogError(errors.Wrap(err, "unable to send graphql-ws complete response"))
+		}
+	default:
+		c.beginClosing(4400, "unknown message type")
+	}
+}
+
+var keepAlivePreparedMessage *websocket.PreparedMessage
+
+func init() {
+	data, err := jsoniter.Marshal(&Message{
+		Type: MessageTypePong,
+	})
+	if err != nil {
+		panic(errors.Wrap(err, "error marshaling message"))
+	}
+	prepared, err := websocket.NewPreparedMessage(websocket.TextMessage, data)
+	if err != nil {
+		panic(errors.Wrap(err, "error preparing message"))
+	}
+	keepAlivePreparedMessage = prepared
+}
+
+func (c *Connection) writeLoop() {
+	defer c.finishClosing()
+	defer close(c.writeLoopDone)
+
+	defer c.conn.Close()
+
+	keepAliveTicker := time.NewTicker(15 * time.Second)
+	defer keepAliveTicker.Stop()
+
+	for {
+		var msg *websocket.PreparedMessage
+		select {
+		case outgoing := <-c.outgoing:
+			msg = outgoing
+		case <-keepAliveTicker.C:
+			msg = keepAlivePreparedMessage
+		case msg := <-c.closeMessage:
+			// make sure we send any outgoing messages before closing (e.g. to make sure we send
+			// back the error after a bad init)
+			for done := false; !done; {
+				select {
+				case msg := <-c.outgoing:
+					c.conn.SetWriteDeadline(time.Now().Add(time.Second))
+					if err := c.conn.WritePreparedMessage(msg); err != nil {
+						if !websocket.IsCloseError(err, websocket.CloseAbnormalClosure, websocket.CloseGoingAway) && err != websocket.ErrCloseSent {
+							c.Handler.LogError(errors.Wrap(err, "websocket write error"))
+						}
+						done = true
+					}
+				default:
+					done = true
+				}
+			}
+
+			// initiate the close handshake
+			if err := c.conn.WriteMessage(websocket.CloseMessage, msg); err != nil {
+				c.Handler.LogError(errors.Wrap(err, "websocket control write error"))
+			}
+			// wait for the response, then close the connection
+			select {
+			case <-c.closeReceived:
+			case <-c.readLoopDone:
+			case <-time.After(time.Second):
+			}
+			return
+		case <-c.closeReceived:
+			// the client initiated the close handshake
+			if err := c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "close requested by client")); err != nil {
+				c.Handler.LogError(errors.Wrap(err, "websocket control write error"))
+			}
+			return
+		}
+
+		c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+
+		if err := c.conn.WritePreparedMessage(msg); err != nil {
+			if !websocket.IsCloseError(err, websocket.CloseAbnormalClosure, websocket.CloseGoingAway) && err != websocket.ErrCloseSent {
+				c.Handler.LogError(errors.Wrap(err, "websocket write error"))
+			}
+			return
+		}
+	}
+}
+
+func (c *Connection) beginClosing(code int, text string) {
+	c.beginClosingOnce.Do(func() {
+		c.closeMessage <- websocket.FormatCloseMessage(code, text)
+		close(c.close)
+		c.Handler.Cancel()
+	})
+}
+
+func (c *Connection) finishClosing() {
+	<-c.readLoopDone
+	<-c.writeLoopDone
+	invokeHandler := false
+	c.finishClosingOnce.Do(func() {
+		invokeHandler = true
+	})
+	if invokeHandler {
+		c.Handler.HandleClose()
+	}
+}

--- a/graphql/transport/graphqltransportws/protocol.go
+++ b/graphql/transport/graphqltransportws/protocol.go
@@ -1,0 +1,29 @@
+package graphqltransportws
+
+import (
+	"encoding/json"
+)
+
+const WebSocketSubprotocol = "graphql-transport-ws"
+
+// MessageType represents a GraphQL-WS message type.
+type MessageType string
+
+// MessageType represents a GraphQL-WS message type.
+const (
+	MessageTypeConnectionInit MessageType = "connection_init"
+	MessageTypeConnectionAck  MessageType = "connection_ack"
+	MessageTypePing           MessageType = "ping"
+	MessageTypePong           MessageType = "pong"
+	MessageTypeSubscribe      MessageType = "subscribe"
+	MessageTypeNext           MessageType = "next"
+	MessageTypeError          MessageType = "error"
+	MessageTypeComplete       MessageType = "complete"
+)
+
+// Message represents a GraphQL-WS message. This can be used for both client and server messages.
+type Message struct {
+	Id      string          `json:"id,omitempty"`
+	Type    MessageType     `json:"type"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}

--- a/graphql/transport/graphqlws/README.md
+++ b/graphql/transport/graphqlws/README.md
@@ -1,0 +1,3 @@
+# graphqlws
+
+This is the implementation of the "graphql-ws" protocol defined by [apollographql/subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws).

--- a/graphql/transport/graphqlws/protocol.go
+++ b/graphql/transport/graphqlws/protocol.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 )
 
+const WebSocketSubprotocol = "graphql-ws"
+
 // MessageType represents a GraphQL-WS message type.
 type MessageType string
 

--- a/graphqlws_test.go
+++ b/graphqlws_test.go
@@ -15,7 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ccbrown/api-fu/graphql"
-	"github.com/ccbrown/api-fu/graphqlws"
+	"github.com/ccbrown/api-fu/graphql/transport/graphqltransportws"
+	"github.com/ccbrown/api-fu/graphql/transport/graphqlws"
 )
 
 func TestGraphQLWS(t *testing.T) {
@@ -56,7 +57,7 @@ func TestGraphQLWS(t *testing.T) {
 
 	dialer := &websocket.Dialer{
 		HandshakeTimeout: time.Second,
-		Subprotocols:     []string{"graphql-ws"},
+		Subprotocols:     []string{graphqlws.WebSocketSubprotocol},
 	}
 
 	var conn *websocket.Conn
@@ -172,7 +173,7 @@ func TestGraphQLWS_InitParameters(t *testing.T) {
 
 	dialer := &websocket.Dialer{
 		HandshakeTimeout: time.Second,
-		Subprotocols:     []string{"graphql-ws"},
+		Subprotocols:     []string{graphqlws.WebSocketSubprotocol},
 	}
 
 	for name, tc := range map[string]struct {
@@ -245,6 +246,230 @@ func TestGraphQLWS_InitParameters(t *testing.T) {
 				require.NoError(t, conn.ReadJSON(&msg))
 				assert.Equal(t, "query", msg.Id)
 				assert.Equal(t, graphqlws.MessageTypeComplete, msg.Type)
+			}
+		})
+	}
+}
+
+func TestGraphQLWSTransport(t *testing.T) {
+	var testCfg Config
+
+	testCfg.AddQueryField("foo", &graphql.FieldDefinition{
+		Type: graphql.BooleanType,
+		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+			return true, nil
+		},
+	})
+
+	testCfg.AddSubscription("time", &graphql.FieldDefinition{
+		Type: graphql.NewNonNullType(DateTimeType),
+		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+			if ctx.IsSubscribe {
+				ticker := time.NewTicker(time.Second)
+				return &SubscriptionSourceStream{
+					EventChannel: ticker.C,
+					Stop:         ticker.Stop,
+				}, nil
+			} else if ctx.Object != nil {
+				return ctx.Object, nil
+			} else {
+				return nil, fmt.Errorf("subscriptions are not supported using this protocol")
+			}
+		},
+	})
+
+	api, err := NewAPI(&testCfg)
+	require.NoError(t, err)
+	defer api.CloseHijackedConnections()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		api.ServeGraphQLWS(w, r)
+	}))
+	defer ts.Close()
+
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: time.Second,
+		Subprotocols:     []string{graphqltransportws.WebSocketSubprotocol},
+	}
+
+	var conn *websocket.Conn
+	for attempts := 0; attempts < 100; attempts++ {
+		clientConn, _, err := dialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+		if err != nil {
+			time.Sleep(time.Millisecond * 10)
+		} else {
+			conn = clientConn
+			break
+		}
+	}
+	require.NotNil(t, conn)
+	defer func() {
+		assert.NoError(t, conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "closing")))
+		conn.Close()
+	}()
+
+	require.NoError(t, conn.WriteJSON(map[string]string{
+		"id":   "init",
+		"type": "connection_init",
+	}))
+
+	var msg graphqltransportws.Message
+
+	require.NoError(t, conn.ReadJSON(&msg))
+	assert.Equal(t, graphqltransportws.MessageTypeConnectionAck, msg.Type)
+
+	t.Run("Query", func(t *testing.T) {
+		require.NoError(t, conn.WriteJSON(map[string]interface{}{
+			"id":   "query",
+			"type": "subscribe",
+			"payload": map[string]interface{}{
+				"query": `
+					{
+						foo
+					}
+				`,
+			},
+		}))
+
+		require.NoError(t, conn.ReadJSON(&msg))
+		assert.Equal(t, "query", msg.Id)
+		assert.Equal(t, graphqltransportws.MessageTypeNext, msg.Type)
+
+		require.NoError(t, conn.ReadJSON(&msg))
+		assert.Equal(t, "query", msg.Id)
+		assert.Equal(t, graphqltransportws.MessageTypeComplete, msg.Type)
+	})
+
+	t.Run("Subscription", func(t *testing.T) {
+		require.NoError(t, conn.WriteJSON(map[string]interface{}{
+			"id":   "sub",
+			"type": "subscribe",
+			"payload": map[string]interface{}{
+				"query": `
+					subscription {
+						time
+					}
+				`,
+			},
+		}))
+
+		require.NoError(t, conn.ReadJSON(&msg))
+		assert.Equal(t, "sub", msg.Id)
+		assert.Equal(t, graphqltransportws.MessageTypeNext, msg.Type)
+
+		require.NoError(t, conn.WriteJSON(map[string]interface{}{
+			"id":   "sub",
+			"type": "complete",
+		}))
+
+		require.NoError(t, conn.ReadJSON(&msg))
+		assert.Equal(t, "sub", msg.Id)
+		assert.Equal(t, graphqltransportws.MessageTypeComplete, msg.Type)
+	})
+}
+
+func TestGraphQLTransportWS_InitParameters(t *testing.T) {
+	var testCfg Config
+
+	testCfg.AddQueryField("whoami", &graphql.FieldDefinition{
+		Type: graphql.StringType,
+		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+			return ctx.Context.Value("name"), nil
+		},
+	})
+
+	testCfg.HandleGraphQLWSInit = func(ctx context.Context, parameters json.RawMessage) (context.Context, error) {
+		var params struct {
+			Name string
+		}
+		if err := json.Unmarshal(parameters, &params); err != nil {
+			return ctx, err
+		} else if params.Name == "" {
+			return ctx, fmt.Errorf("no name")
+		}
+		ctx = context.WithValue(ctx, "name", params.Name)
+		return ctx, nil
+	}
+
+	api, err := NewAPI(&testCfg)
+	require.NoError(t, err)
+	defer api.CloseHijackedConnections()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		api.ServeGraphQLWS(w, r)
+	}))
+	defer ts.Close()
+
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: time.Second,
+		Subprotocols:     []string{graphqltransportws.WebSocketSubprotocol},
+	}
+
+	for name, tc := range map[string]struct {
+		Parameters    json.RawMessage
+		ExpectedName  string
+		ExpectedError string
+	}{
+		"Ok": {
+			ExpectedName: "alice",
+			Parameters:   json.RawMessage(`{"name": "alice"}`),
+		},
+		"NoName": {
+			ExpectedError: "websocket: close 4403: no name",
+			Parameters:    json.RawMessage(`{"foo": "bar"}`),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var conn *websocket.Conn
+			for attempts := 0; attempts < 100; attempts++ {
+				clientConn, _, err := dialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+				if err != nil {
+					time.Sleep(time.Millisecond * 10)
+				} else {
+					conn = clientConn
+					break
+				}
+			}
+			require.NotNil(t, conn)
+			defer func() {
+				conn.Close()
+			}()
+
+			require.NoError(t, conn.WriteJSON(map[string]interface{}{
+				"type":    "connection_init",
+				"payload": tc.Parameters,
+			}))
+
+			var msg graphqltransportws.Message
+
+			if tc.ExpectedError != "" {
+				err := conn.ReadJSON(&msg)
+				require.Error(t, err)
+				assert.Equal(t, err.Error(), tc.ExpectedError)
+			} else {
+				require.NoError(t, conn.ReadJSON(&msg))
+				assert.Equal(t, graphqltransportws.MessageTypeConnectionAck, msg.Type)
+
+				require.NoError(t, conn.WriteJSON(map[string]interface{}{
+					"id":   "query",
+					"type": "subscribe",
+					"payload": map[string]interface{}{
+						"query": `
+					{
+						whoami
+					}
+				`,
+					},
+				}))
+
+				require.NoError(t, conn.ReadJSON(&msg))
+				assert.Equal(t, "query", msg.Id)
+				assert.Equal(t, graphqltransportws.MessageTypeNext, msg.Type)
+				assert.JSONEq(t, fmt.Sprintf(`{"data": {"whoami": %#v}}`, tc.ExpectedName), string(msg.Payload))
+
+				require.NoError(t, conn.ReadJSON(&msg))
+				assert.Equal(t, "query", msg.Id)
+				assert.Equal(t, graphqltransportws.MessageTypeComplete, msg.Type)
 			}
 		})
 	}


### PR DESCRIPTION
## What it Does

This adds support for the newer graphql-transport-ws subscription protocol: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
