### PR TITLE
add schema definition deep copying and mechanism to inspect or alter schema definitions before compilation

### DIFF
--- a/graphql/schema/deep_copy.go
+++ b/graphql/schema/deep_copy.go
@@ -1,0 +1,266 @@
+package schema
+
+import "fmt"
+
+func deepCopySchemaDefinition(def *SchemaDefinition) *SchemaDefinition {
+	newNamedTypes := make(map[string]NamedType)
+
+	// Create shallow copies for all the named types.
+	Inspect(def, func(node any) bool {
+		if node, ok := node.(NamedType); ok {
+			if _, ok := newNamedTypes[node.TypeName()]; ok {
+				return false
+			}
+			switch t := node.(type) {
+			case *UnionType:
+				copy := *t
+				newNamedTypes[t.Name] = &copy
+			case *InterfaceType:
+				copy := *t
+				newNamedTypes[t.Name] = &copy
+			case *InputObjectType:
+				copy := *t
+				newNamedTypes[t.Name] = &copy
+			case *ObjectType:
+				copy := *t
+				newNamedTypes[t.Name] = &copy
+			case *EnumType:
+				copy := *t
+				newNamedTypes[t.Name] = &copy
+			case *ScalarType:
+				copy := *t
+				newNamedTypes[t.Name] = &copy
+			default:
+				panic(fmt.Errorf("unknown named type type: %T", t))
+			}
+		}
+
+		return true
+	})
+
+	// Now update all of those shallow copies to point to each other.
+	for _, t := range newNamedTypes {
+		fixNamedTypePointers(t, newNamedTypes)
+	}
+
+	ret := &SchemaDefinition{}
+	if def.Query != nil {
+		ret.Query = newNamedTypes[def.Query.Name].(*ObjectType)
+	}
+	if def.Mutation != nil {
+		ret.Mutation = newNamedTypes[def.Mutation.Name].(*ObjectType)
+	}
+	if def.Subscription != nil {
+		ret.Subscription = newNamedTypes[def.Subscription.Name].(*ObjectType)
+	}
+
+	if def.Directives != nil {
+		ret.Directives = make(map[string]*DirectiveDefinition, len(def.Directives))
+		for k, v := range def.Directives {
+			newValue := *v
+			fixNamedTypePointers(&newValue, newNamedTypes)
+			ret.Directives[k] = &newValue
+		}
+	}
+
+	if def.AdditionalTypes != nil {
+		ret.AdditionalTypes = make([]NamedType, len(def.AdditionalTypes))
+		for i, v := range def.AdditionalTypes {
+			ret.AdditionalTypes[i] = newNamedTypes[v.TypeName()]
+		}
+	}
+
+	return ret
+}
+
+func fixTypePointer(t Type, namedTypes map[string]NamedType) Type {
+	switch t := t.(type) {
+	case NamedType:
+		if _, ok := BuiltInTypes[t.TypeName()]; ok {
+			return t
+		} else if ret, ok := namedTypes[t.TypeName()]; ok {
+			return ret
+		}
+		return t
+	case *NonNullType:
+		return NewNonNullType(fixTypePointer(t.Unwrap(), namedTypes))
+	case *ListType:
+		return NewListType(fixTypePointer(t.Unwrap(), namedTypes))
+	default:
+		panic(fmt.Errorf("unknown named type type: %T", t))
+	}
+	return nil
+}
+
+// Updates pointers to named types to those contained in the given map. This function does not
+// recurse into descendant named types.
+func fixNamedTypePointers(node any, namedTypes map[string]NamedType) {
+	switch n := node.(type) {
+	case *UnionType:
+		if n.Directives != nil {
+			newValues := make([]*Directive, len(n.Directives))
+			for i, v := range n.Directives {
+				newValue := *v
+				fixNamedTypePointers(&newValue, namedTypes)
+				newValues[i] = &newValue
+			}
+			n.Directives = newValues
+		}
+		if n.MemberTypes != nil {
+			newValues := make([]*ObjectType, len(n.MemberTypes))
+			for i, v := range n.MemberTypes {
+				if newValue, ok := namedTypes[v.Name].(*ObjectType); ok {
+					newValues[i] = newValue
+				} else {
+					newValues[i] = v
+				}
+			}
+			n.MemberTypes = newValues
+		}
+	case *InterfaceType:
+		if n.Directives != nil {
+			newValues := make([]*Directive, len(n.Directives))
+			for i, v := range n.Directives {
+				newValue := *v
+				fixNamedTypePointers(&newValue, namedTypes)
+				newValues[i] = &newValue
+			}
+			n.Directives = newValues
+		}
+		if n.Fields != nil {
+			newValues := make(map[string]*FieldDefinition, len(n.Fields))
+			for k, v := range n.Fields {
+				newField := *v
+				fixNamedTypePointers(&newField, namedTypes)
+				newValues[k] = &newField
+			}
+			n.Fields = newValues
+		}
+	case *InputObjectType:
+		if n.Directives != nil {
+			newValues := make([]*Directive, len(n.Directives))
+			for i, v := range n.Directives {
+				newValue := *v
+				fixNamedTypePointers(&newValue, namedTypes)
+				newValues[i] = &newValue
+			}
+			n.Directives = newValues
+		}
+		if n.Fields != nil {
+			newValues := make(map[string]*InputValueDefinition, len(n.Fields))
+			for k, v := range n.Fields {
+				newField := *v
+				fixNamedTypePointers(&newField, namedTypes)
+				newValues[k] = &newField
+			}
+			n.Fields = newValues
+		}
+	case *ObjectType:
+		if n.Directives != nil {
+			newValues := make([]*Directive, len(n.Directives))
+			for i, v := range n.Directives {
+				newValue := *v
+				fixNamedTypePointers(&newValue, namedTypes)
+				newValues[i] = &newValue
+			}
+			n.Directives = newValues
+		}
+		if n.Fields != nil {
+			newValues := make(map[string]*FieldDefinition, len(n.Fields))
+			for k, v := range n.Fields {
+				newField := *v
+				fixNamedTypePointers(&newField, namedTypes)
+				newValues[k] = &newField
+			}
+			n.Fields = newValues
+		}
+		if n.ImplementedInterfaces != nil {
+			newValues := make([]*InterfaceType, len(n.ImplementedInterfaces))
+			for i, v := range n.ImplementedInterfaces {
+				if newValue, ok := namedTypes[v.Name].(*InterfaceType); ok {
+					newValues[i] = newValue
+				} else {
+					newValues[i] = v
+				}
+			}
+			n.ImplementedInterfaces = newValues
+		}
+	case *FieldDefinition:
+		if n.Directives != nil {
+			newValues := make([]*Directive, len(n.Directives))
+			for i, v := range n.Directives {
+				newValue := *v
+				fixNamedTypePointers(&newValue, namedTypes)
+				newValues[i] = &newValue
+			}
+			n.Directives = newValues
+		}
+		n.Type = fixTypePointer(n.Type, namedTypes)
+		if n.Arguments != nil {
+			newValues := make(map[string]*InputValueDefinition, len(n.Arguments))
+			for k, v := range n.Arguments {
+				newField := *v
+				fixNamedTypePointers(&newField, namedTypes)
+				newValues[k] = &newField
+			}
+			n.Arguments = newValues
+		}
+	case *InputValueDefinition:
+		if n.Directives != nil {
+			newValues := make([]*Directive, len(n.Directives))
+			for i, v := range n.Directives {
+				newValue := *v
+				fixNamedTypePointers(&newValue, namedTypes)
+				newValues[i] = &newValue
+			}
+			n.Directives = newValues
+		}
+		n.Type = fixTypePointer(n.Type, namedTypes)
+	case *Directive:
+		if n.Definition != nil {
+			newDefinition := *n.Definition
+			fixNamedTypePointers(&newDefinition, namedTypes)
+			n.Definition = &newDefinition
+		}
+	case *DirectiveDefinition:
+		if n.Arguments != nil {
+			newValues := make(map[string]*InputValueDefinition, len(n.Arguments))
+			for k, v := range n.Arguments {
+				newField := *v
+				fixNamedTypePointers(&newField, namedTypes)
+				newValues[k] = &newField
+			}
+			n.Arguments = newValues
+		}
+	case *EnumType:
+		if n.Directives != nil {
+			newValues := make([]*Directive, len(n.Directives))
+			for i, v := range n.Directives {
+				newValue := *v
+				fixNamedTypePointers(&newValue, namedTypes)
+				newValues[i] = &newValue
+			}
+			n.Directives = newValues
+		}
+		if n.Values != nil {
+			newValues := make(map[string]*EnumValueDefinition, len(n.Values))
+			for k, v := range n.Values {
+				newValue := *v
+				newValues[k] = &newValue
+			}
+			n.Values = newValues
+		}
+	case *ScalarType:
+		if n.Directives != nil {
+			newValues := make([]*Directive, len(n.Directives))
+			for i, v := range n.Directives {
+				newValue := *v
+				fixNamedTypePointers(&newValue, namedTypes)
+				newValues[i] = &newValue
+			}
+			n.Directives = newValues
+		}
+	default:
+		panic(fmt.Errorf("unexpected node type: %T", n))
+	}
+}

--- a/graphql/schema/deep_copy_test.go
+++ b/graphql/schema/deep_copy_test.go
@@ -1,0 +1,167 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var petType = &InterfaceType{
+	Name: "Pet",
+	Fields: map[string]*FieldDefinition{
+		"nickname": {
+			Type: StringType,
+		},
+	},
+}
+
+var dogType = &ObjectType{
+	Name: "Dog",
+	Fields: map[string]*FieldDefinition{
+		"nickname": {
+			Type: StringType,
+		},
+		"barkVolume": {
+			Type: IntType,
+		},
+	},
+	ImplementedInterfaces: []*InterfaceType{petType},
+	IsTypeOf:              func(interface{}) bool { return false },
+}
+
+var fooBarEnumType = &EnumType{
+	Name: "FooBarEnum",
+	Values: map[string]*EnumValueDefinition{
+		"FOO": {},
+		"BAR": {},
+	},
+}
+
+var objectType = &ObjectType{
+	Name: "Object",
+	Fields: map[string]*FieldDefinition{
+		"pet": {
+			Type: petType,
+			Arguments: map[string]*InputValueDefinition{
+				"booleanArg": {
+					Type: BooleanType,
+				},
+			},
+		},
+		"union": {
+			Type: &UnionType{
+				Name: "Union",
+				MemberTypes: []*ObjectType{
+					{
+						Name: "UnionObjectA",
+						Fields: map[string]*FieldDefinition{
+							"a": {
+								Type: StringType,
+							},
+							"scalar": {
+								Type: StringType,
+							},
+						},
+						IsTypeOf: func(interface{}) bool { return false },
+					},
+					{
+						Name: "UnionObjectB",
+						Fields: map[string]*FieldDefinition{
+							"b": {
+								Type: StringType,
+							},
+							"scalar": {
+								Type: StringType,
+							},
+						},
+						IsTypeOf: func(interface{}) bool { return false },
+					},
+				},
+			},
+		},
+		"int": {
+			Type: IntType,
+		},
+		"nonNullInt": {
+			Type: NewNonNullType(IntType),
+		},
+		"enum": {
+			Type: fooBarEnumType,
+		},
+	},
+}
+
+func TestDeepCopySchemaDefinition(t *testing.T) {
+	def := &SchemaDefinition{
+		Query: objectType,
+		Directives: map[string]*DirectiveDefinition{
+			"directive": {
+				Locations: []DirectiveLocation{DirectiveLocationField, DirectiveLocationFragmentSpread, DirectiveLocationInlineFragment},
+			},
+		},
+		AdditionalTypes: []NamedType{dogType},
+	}
+
+	getType := func(def *SchemaDefinition, name string) Type {
+		var ret Type
+		Inspect(def, func(node any) bool {
+			if t, ok := node.(NamedType); ok && t.TypeName() == name {
+				ret = t
+				return false
+			}
+			return true
+		})
+		return ret
+	}
+
+	newTypeDescriptions := map[string]string{
+		"Pet":          "new pet description",
+		"Dog":          "new dog description",
+		"FooBarEnum":   "new enum description",
+		"Union":        "new union description",
+		"UnionObjectA": "new union object a description",
+		"UnionObjectB": "new union object b description",
+	}
+
+	// Make a copy of the definition and modify all the types.
+	defCopy := def.Clone()
+	for name, desc := range newTypeDescriptions {
+		switch typ := getType(defCopy, name).(type) {
+		case *ObjectType:
+			typ.Description = desc
+		case *EnumType:
+			typ.Description = desc
+		case *UnionType:
+			typ.Description = desc
+		case *InterfaceType:
+			typ.Description = desc
+		default:
+			t.Fatalf("unexpected type %T for %v", typ, name)
+		}
+	}
+
+	// Make sure the copy is still valid.
+	_, err := New(defCopy)
+	require.NoError(t, err)
+
+	// Make sure the original definition is unchanged.
+	for name := range newTypeDescriptions {
+		switch typ := getType(def, name).(type) {
+		case *ObjectType:
+			assert.Empty(t, typ.Description)
+		case *EnumType:
+			assert.Empty(t, typ.Description)
+		case *UnionType:
+			assert.Empty(t, typ.Description)
+		case *InterfaceType:
+			assert.Empty(t, typ.Description)
+		default:
+			t.Fatalf("unexpected type %T for %v", typ, name)
+		}
+	}
+
+	// Make sure the original is still valid.
+	_, err = New(def)
+	require.NoError(t, err)
+}

--- a/graphql/schema/inspect.go
+++ b/graphql/schema/inspect.go
@@ -25,30 +25,18 @@ func Inspect(node interface{}, f func(interface{}) bool) {
 			Inspect(node, f)
 		}
 	case *UnionType:
-		for _, node := range n.Directives {
-			Inspect(node, f)
-		}
 		for _, node := range n.MemberTypes {
 			Inspect(node, f)
 		}
 	case *InterfaceType:
-		for _, node := range n.Directives {
-			Inspect(node, f)
-		}
 		for _, node := range n.Fields {
 			Inspect(node, f)
 		}
 	case *InputObjectType:
-		for _, node := range n.Directives {
-			Inspect(node, f)
-		}
 		for _, node := range n.Fields {
 			Inspect(node, f)
 		}
 	case *ObjectType:
-		for _, node := range n.Directives {
-			Inspect(node, f)
-		}
 		for _, node := range n.Fields {
 			Inspect(node, f)
 		}
@@ -60,14 +48,10 @@ func Inspect(node interface{}, f func(interface{}) bool) {
 		for _, node := range n.Arguments {
 			Inspect(node, f)
 		}
-		for _, node := range n.Directives {
-			Inspect(node, f)
-		}
 	case *InputValueDefinition:
 		Inspect(n.Type, f)
-		for _, node := range n.Directives {
-			Inspect(node, f)
-		}
+	case *Directive:
+		Inspect(n.Definition, f)
 	case *DirectiveDefinition:
 		for _, node := range n.Arguments {
 			Inspect(node, f)
@@ -76,7 +60,14 @@ func Inspect(node interface{}, f func(interface{}) bool) {
 		Inspect(n.Type, f)
 	case *NonNullType:
 		Inspect(n.Type, f)
-	case *EnumType, *ScalarType:
+	case *EnumType:
+		for _, node := range n.Directives {
+			Inspect(node, f)
+		}
+	case *ScalarType:
+		for _, node := range n.Directives {
+			Inspect(node, f)
+		}
 	default:
 		panic(fmt.Errorf("unknown node type: %T", n))
 	}

--- a/graphql/schema/introspection/introspection_test.go
+++ b/graphql/schema/introspection/introspection_test.go
@@ -105,6 +105,7 @@ func TestIntrospection(t *testing.T) {
 				Locations: []schema.DirectiveLocation{schema.DirectiveLocationField, schema.DirectiveLocationFragmentSpread, schema.DirectiveLocationInlineFragment},
 			},
 		},
+		AdditionalTypes: []schema.NamedType{dogType},
 	})
 	require.NoError(t, err)
 	require.NoError(t, err)

--- a/graphql/schema/schema.go
+++ b/graphql/schema/schema.go
@@ -112,6 +112,12 @@ func New(def *SchemaDefinition) (*Schema, error) {
 	return schema, nil
 }
 
+// Creates a deep copy of the given schema definition. This allows you to safely modify descriptions
+// or other attributes of the schema without modifying the original definition.
+func (def *SchemaDefinition) Clone() *SchemaDefinition {
+	return deepCopySchemaDefinition(def)
+}
+
 type SchemaDefinition struct {
 	// Directives to define within the schema. For example, you might want to add IncludeDirective
 	// and SkipDirective here.


### PR DESCRIPTION
This PR adds a `Clone` method to the schema definition types.

This also adds a mechanism to inspect and alter the schema definition before it's built.

## What it Does

<!-- Does it add a new feature? Does it fix a bug? -->

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
