### PR TITLE
cheaper collectFields cache key

### DIFF
--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -427,12 +427,13 @@ func (e *executor) collectFields(objectType *schema.ObjectType, selections []ast
 	// collectFields can be called many times with the same inputs throughout a query's execution,
 	// so we memoize the return value.
 
-	cacheKeyBytes := make([]byte, len(objectType.Name)+16*len(selections))
+	objectNameLen := len(objectType.Name)
+	cacheKeyBytes := make([]byte, objectNameLen+8*len(selections))
 	copy(cacheKeyBytes, objectType.Name)
 	for i, sel := range selections {
 		pos := sel.Position()
-		binary.LittleEndian.PutUint64(cacheKeyBytes[len(objectType.Name)+i*16:], uint64(pos.Line))
-		binary.LittleEndian.PutUint64(cacheKeyBytes[len(objectType.Name)+i*16+8:], uint64(pos.Column))
+		binary.LittleEndian.PutUint32(cacheKeyBytes[objectNameLen+i*8:], uint32(pos.Line))
+		binary.LittleEndian.PutUint32(cacheKeyBytes[objectNameLen+i*8+4:], uint32(pos.Column))
 	}
 	cacheKey := string(cacheKeyBytes)
 


### PR DESCRIPTION
## What it Does

This makes the internal `collectFields` function cheaper. For small selections, it allocates more, but is faster. For large selections, it allocates significantly less and is much, much faster.

Before:

```
% go test -v ./graphql/executor -bench=BenchmarkExecuteRequest -run asdqweqwe -benchtime 5s
goos: darwin
goarch: arm64
pkg: github.com/ccbrown/api-fu/graphql/executor
BenchmarkExecuteRequest
BenchmarkExecuteRequest-10    	    6174	    879445 ns/op	  796542 B/op	   20444 allocs/op
```

After:

```
% go test -v ./graphql/executor -bench=BenchmarkExecuteRequest -run asdqweqwe -benchtime 5s
goos: darwin
goarch: arm64
pkg: github.com/ccbrown/api-fu/graphql/executor
BenchmarkExecuteRequest
BenchmarkExecuteRequest-10    	    6068	    846561 ns/op	  828877 B/op	   22444 allocs/op
```

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...` and see above benchmark commands.

<!-- Does running this require any special setup or dependencies? -->
