### PR TITLE
make resolver context non-pointer

### DIFF
--- a/api.go
+++ b/api.go
@@ -189,18 +189,18 @@ func Go(ctx context.Context, f func() (interface{}, error)) graphql.ResolvePromi
 }
 
 type batch struct {
-	resolver func([]*graphql.FieldContext) []graphql.ResolveResult
-	items    []*graphql.FieldContext
+	resolver func([]graphql.FieldContext) []graphql.ResolveResult
+	items    []graphql.FieldContext
 	dests    []chan graphql.ResolveResult
 }
 
 // Batch batches up the resolver invocations into a single call. As queries are executed, whenever
 // resolution gets "stuck", all pending batch resolvers will be triggered concurrently. Batch
 // resolvers must return one result for every field context it receives.
-func Batch(f func([]*graphql.FieldContext) []graphql.ResolveResult) func(*graphql.FieldContext) (interface{}, error) {
+func Batch(f func([]graphql.FieldContext) []graphql.ResolveResult) func(graphql.FieldContext) (interface{}, error) {
 	var x int
 	key := &x
-	return func(ctx *graphql.FieldContext) (interface{}, error) {
+	return func(ctx graphql.FieldContext) (interface{}, error) {
 		apiRequest := ctxAPIRequest(ctx.Context)
 		b, ok := apiRequest.batches[key]
 		if !ok {

--- a/api_test.go
+++ b/api_test.go
@@ -33,7 +33,7 @@ func TestGo(t *testing.T) {
 	// If this is not executed asynchronously alongside a matching asyncReceiver, it will deadlock.
 	testCfg.AddQueryField("asyncSender", &graphql.FieldDefinition{
 		Type: graphql.BooleanType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return Go(ctx.Context, func() (interface{}, error) {
 				asyncChannel <- struct{}{}
 				return true, nil
@@ -44,7 +44,7 @@ func TestGo(t *testing.T) {
 	// If this is not executed asynchronously alongside a matching asyncSender, it will deadlock.
 	testCfg.AddQueryField("asyncReceiver", &graphql.FieldDefinition{
 		Type: graphql.BooleanType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return Go(ctx.Context, func() (interface{}, error) {
 				<-asyncChannel
 				return true, nil
@@ -72,7 +72,7 @@ func TestBatch(t *testing.T) {
 
 	testCfg.AddQueryField("batched1", &graphql.FieldDefinition{
 		Type: graphql.IntType,
-		Resolve: Batch(func(ctx []*graphql.FieldContext) []graphql.ResolveResult {
+		Resolve: Batch(func(ctx []graphql.FieldContext) []graphql.ResolveResult {
 			assert.Len(t, ctx, 1)
 			return []graphql.ResolveResult{
 				{Value: 1, Error: nil},
@@ -82,7 +82,7 @@ func TestBatch(t *testing.T) {
 
 	testCfg.AddQueryField("batched2", &graphql.FieldDefinition{
 		Type: graphql.IntType,
-		Resolve: Batch(func(ctx []*graphql.FieldContext) []graphql.ResolveResult {
+		Resolve: Batch(func(ctx []graphql.FieldContext) []graphql.ResolveResult {
 			assert.Len(t, ctx, 2)
 			return []graphql.ResolveResult{
 				{Value: 1, Error: nil},
@@ -200,7 +200,7 @@ func TestMutation(t *testing.T) {
 
 	testCfg.AddMutation("mut", &graphql.FieldDefinition{
 		Type: graphql.BooleanType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return true, nil
 		},
 	})

--- a/config.go
+++ b/config.go
@@ -93,7 +93,7 @@ func (cfg *Config) init() {
 						},
 					},
 					Cost: graphql.FieldResolverCost(1),
-					Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+					Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 						// TODO: batching?
 						return ctxAPI(ctx.Context).resolveNodeByGlobalId(ctx.Context, ctx.Arguments["id"].(string))
 					},
@@ -106,14 +106,14 @@ func (cfg *Config) init() {
 							Type: graphql.NewNonNullType(graphql.NewListType(graphql.NewNonNullType(graphql.IDType))),
 						},
 					},
-					Cost: func(ctx *graphql.FieldCostContext) graphql.FieldCost {
+					Cost: func(ctx graphql.FieldCostContext) graphql.FieldCost {
 						ids, _ := ctx.Arguments["ids"].([]interface{})
 						return graphql.FieldCost{
 							Resolver:   1,
 							Multiplier: len(ids),
 						}
 					},
-					Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+					Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 						var ids []string
 						for _, id := range ctx.Arguments["ids"].([]interface{}) {
 							ids = append(ids, id.(string))
@@ -231,7 +231,7 @@ func (cfg *Config) AddMutation(name string, def *graphql.FieldDefinition) {
 // When this happens, you should return a pointer to a SubscriptionSourceStream (or an error). For
 // example:
 //
-//	Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+//	Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 //	    if ctx.IsSubscribe {
 //	        ticker := time.NewTicker(time.Second)
 //	        return &apifu.SubscriptionSourceStream{

--- a/examples/chat/api/channel.go
+++ b/examples/chat/api/channel.go
@@ -40,12 +40,12 @@ func init() {
 			EdgeFields: map[string]*graphql.FieldDefinition{
 				"node": {
 					Type: graphql.NewNonNullType(messageType),
-					Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+					Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 						return ctx.Object, nil
 					},
 				},
 			},
-			EdgeGetter: func(ctx *graphql.FieldContext, minTime time.Time, maxTime time.Time, limit int) (interface{}, error) {
+			EdgeGetter: func(ctx graphql.FieldContext, minTime time.Time, maxTime time.Time, limit int) (interface{}, error) {
 				return ctxSession(ctx.Context).GetMessagesByChannelIdAndTimeRange(ctx.Object.(*model.Channel).Id, minTime, maxTime, limit)
 			},
 		}),
@@ -59,7 +59,7 @@ func init() {
 			Fields: map[string]*graphql.FieldDefinition{
 				"channel": {
 					Type: graphql.NewNonNullType(channelType),
-					Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+					Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 						return ctx.Object, nil
 					},
 				},
@@ -82,7 +82,7 @@ func init() {
 				}),
 			},
 		},
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return ctxSession(ctx.Context).CreateChannel(ctx.Arguments["channel"].(*model.Channel))
 		},
 	})
@@ -107,7 +107,7 @@ func init() {
 		EdgeFields: map[string]*graphql.FieldDefinition{
 			"node": {
 				Type: graphql.NewNonNullType(channelType),
-				Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+				Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 					return ctx.Object, nil
 				},
 			},
@@ -115,7 +115,7 @@ func init() {
 		CursorType: reflect.TypeOf(cursor{}),
 		// If we assume the server will always have a relatively small number of channels, we can
 		// keep things simple using ResolveAllEdges.
-		ResolveAllEdges: func(ctx *graphql.FieldContext) (interface{}, func(a, b interface{}) bool, error) {
+		ResolveAllEdges: func(ctx graphql.FieldContext) (interface{}, func(a, b interface{}) bool, error) {
 			channels, err := ctxSession(ctx.Context).GetChannels()
 			return channels, func(a, b interface{}) bool {
 				ac, bc := a.(cursor), b.(cursor)

--- a/examples/chat/api/message.go
+++ b/examples/chat/api/message.go
@@ -35,7 +35,7 @@ func init() {
 			Fields: map[string]*graphql.FieldDefinition{
 				"message": {
 					Type: graphql.NewNonNullType(messageType),
-					Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+					Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 						return ctx.Object, nil
 					},
 				},
@@ -62,7 +62,7 @@ func init() {
 				}),
 			},
 		},
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return ctxSession(ctx.Context).CreateMessage(ctx.Arguments["message"].(*model.Message))
 		},
 	})

--- a/examples/chat/api/user.go
+++ b/examples/chat/api/user.go
@@ -29,7 +29,7 @@ func init() {
 			Fields: map[string]*graphql.FieldDefinition{
 				"user": {
 					Type: graphql.NewNonNullType(userType),
-					Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+					Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 						return ctx.Object, nil
 					},
 				},
@@ -56,14 +56,14 @@ func init() {
 				}),
 			},
 		},
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return ctxSession(ctx.Context).CreateUser(ctx.Arguments["user"].(*model.User))
 		},
 	})
 
 	fuCfg.AddQueryField("authenticatedUser", &graphql.FieldDefinition{
 		Type: userType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return ctxSession(ctx.Context).User, nil
 		},
 	})

--- a/fields.go
+++ b/fields.go
@@ -19,7 +19,7 @@ func OwnID(fieldName string) *graphql.FieldDefinition {
 	return &graphql.FieldDefinition{
 		Type: graphql.NewNonNullType(graphql.IDType),
 		Cost: graphql.FieldResolverCost(0),
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			cfg := ctxAPI(ctx.Context).config
 			modelType := normalizeModelType(reflect.TypeOf(ctx.Object))
 			nodeType := cfg.nodeTypesByModel[modelType]
@@ -33,7 +33,7 @@ func NonNullNodeID(modelType reflect.Type, fieldName string) *graphql.FieldDefin
 	return &graphql.FieldDefinition{
 		Type: graphql.NewNonNullType(graphql.IDType),
 		Cost: graphql.FieldResolverCost(0),
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			cfg := ctxAPI(ctx.Context).config
 			modelType = normalizeModelType(modelType)
 			nodeType := cfg.nodeTypesByModel[modelType]
@@ -48,7 +48,7 @@ func NonEmptyString(fieldName string) *graphql.FieldDefinition {
 	return &graphql.FieldDefinition{
 		Type: graphql.StringType,
 		Cost: graphql.FieldResolverCost(0),
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			if s := fieldValue(ctx.Object, fieldName); s != "" {
 				return s, nil
 			}
@@ -62,7 +62,7 @@ func NonNull(t graphql.Type, fieldName string) *graphql.FieldDefinition {
 	return &graphql.FieldDefinition{
 		Type: graphql.NewNonNullType(t),
 		Cost: graphql.FieldResolverCost(0),
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return fieldValue(ctx.Object, fieldName), nil
 		},
 	}
@@ -73,7 +73,7 @@ func NonNull(t graphql.Type, fieldName string) *graphql.FieldDefinition {
 func Node(nodeType *graphql.ObjectType, idFieldName string) *graphql.FieldDefinition {
 	return &graphql.FieldDefinition{
 		Type: nodeType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			api := ctxAPI(ctx.Context)
 			nodeType, ok := api.config.nodeTypesByObjectType[nodeType]
 			if !ok {

--- a/fields_test.go
+++ b/fields_test.go
@@ -62,7 +62,7 @@ func TestFields(t *testing.T) {
 				"nid": NonNullNodeID(reflect.TypeOf(node{}), "NodeId"),
 			},
 		},
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return struct {
 				Int    int
 				S0     string

--- a/graphql/benchmarks/apifu_test.go
+++ b/graphql/benchmarks/apifu_test.go
@@ -19,7 +19,7 @@ func BenchmarkAPIFu(b *testing.B) {
 	objectType.Fields = map[string]*graphql.FieldDefinition{
 		"string": {
 			Type: graphql.StringType,
-			Resolve: func(*graphql.FieldContext) (interface{}, error) {
+			Resolve: func(graphql.FieldContext) (interface{}, error) {
 				return "foo", nil
 			},
 		},
@@ -30,7 +30,7 @@ func BenchmarkAPIFu(b *testing.B) {
 					Type: graphql.NewNonNullType(graphql.IntType),
 				},
 			},
-			Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+			Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 				return make([]struct{}, ctx.Arguments["count"].(int)), nil
 			},
 		},

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -171,7 +171,7 @@ func (e *executor) subscribe(initialValue interface{}) (interface{}, *Error) {
 		return nil, err
 	}
 
-	resolveValue, resolveErr := fieldDef.Resolve(&schema.FieldContext{
+	resolveValue, resolveErr := fieldDef.Resolve(schema.FieldContext{
 		Context:     e.Context,
 		Schema:      e.Schema,
 		Object:      initialValue,
@@ -302,7 +302,7 @@ func (e *executor) executeField(objectValue interface{}, fields []*ast.Field, fi
 	if err := e.Context.Err(); err != nil {
 		return future.Err[any](newFieldResolveError(fields, err, path))
 	}
-	resolvedValue, err := fieldDef.Resolve(&schema.FieldContext{
+	resolvedValue, err := fieldDef.Resolve(schema.FieldContext{
 		Context:   e.Context,
 		Schema:    e.Schema,
 		Object:    objectValue,

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -34,13 +34,13 @@ var dogType = &schema.ObjectType{
 	Fields: map[string]*schema.FieldDefinition{
 		"nickname": {
 			Type: schema.StringType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return "fido", nil
 			},
 		},
 		"barkVolume": {
 			Type: schema.IntType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return 10, nil
 			},
 		},
@@ -57,13 +57,13 @@ var catType = &schema.ObjectType{
 	Fields: map[string]*schema.FieldDefinition{
 		"nickname": {
 			Type: schema.StringType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return "fluffy", nil
 			},
 		},
 		"meowVolume": {
 			Type: schema.IntType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return 10, nil
 			},
 		},
@@ -89,25 +89,25 @@ func init() {
 	objectType.Fields = map[string]*schema.FieldDefinition{
 		"intOne": {
 			Type: schema.IntType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return 1, nil
 			},
 		},
 		"pet": {
 			Type: petType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return dog{}, nil
 			},
 		},
 		"intTwo": {
 			Type: schema.IntType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return 2, nil
 			},
 		},
 		"asyncString": {
 			Type: schema.StringType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				ch := make(ResolvePromise, 1)
 				stringPromises = append(stringPromises, ch)
 				return ResolvePromise(ch), nil
@@ -115,31 +115,31 @@ func init() {
 		},
 		"stringFoo": {
 			Type: schema.StringType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return "foo", nil
 			},
 		},
 		"object": {
 			Type: objectType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return &object{}, nil
 			},
 		},
 		"nonNullIntListWithNull": {
 			Type: schema.NewListType(schema.NewNonNullType(schema.IntType)),
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return []interface{}{1, nil, 3}, nil
 			},
 		},
 		"objectsWithError": {
 			Type: schema.NewListType(objectType),
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return []*object{{}, {Error: fmt.Errorf("error")}, {}}, nil
 			},
 		},
 		"intOneOrError": {
 			Type: schema.IntType,
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				if err := ctx.Object.(*object).Error; err != nil {
 					return nil, err
 				}
@@ -148,25 +148,25 @@ func init() {
 		},
 		"error": {
 			Type: schema.IntType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return nil, fmt.Errorf("error")
 			},
 		},
 		"nonNullError": {
 			Type: schema.NewNonNullType(schema.IntType),
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return nil, fmt.Errorf("error")
 			},
 		},
 		"badResolveValue": {
 			Type: schema.IntType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return &struct{}{}, nil
 			},
 		},
 		"intListWithBadResolveValue": {
 			Type: schema.NewListType(schema.IntType),
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return []interface{}{1, &struct{}{}, 3}, nil
 			},
 		},
@@ -179,7 +179,7 @@ var mutationType = &schema.ObjectType{
 	Fields: map[string]*schema.FieldDefinition{
 		"asyncString": {
 			Type: schema.StringType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				ch := make(ResolvePromise, 1)
 				stringPromises = append(stringPromises, ch)
 				return ResolvePromise(ch), nil
@@ -191,7 +191,7 @@ var mutationType = &schema.ObjectType{
 				Fields: map[string]*schema.FieldDefinition{
 					"theNumber": {
 						Type: schema.NewNonNullType(schema.IntType),
-						Resolve: func(*schema.FieldContext) (interface{}, error) {
+						Resolve: func(schema.FieldContext) (interface{}, error) {
 							return theNumber, nil
 						},
 					},
@@ -202,7 +202,7 @@ var mutationType = &schema.ObjectType{
 					Type: schema.NewNonNullType(schema.IntType),
 				},
 			},
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				theNumber = ctx.Arguments["newNumber"].(int)
 				return struct{}{}, nil
 			},
@@ -218,7 +218,7 @@ func TestSubscribe(t *testing.T) {
 			Fields: map[string]*schema.FieldDefinition{
 				"int": {
 					Type: schema.NewNonNullType(schema.IntType),
-					Resolve: func(*schema.FieldContext) (interface{}, error) {
+					Resolve: func(schema.FieldContext) (interface{}, error) {
 						return 1, nil
 					},
 				},
@@ -495,7 +495,7 @@ func BenchmarkExecuteRequest(b *testing.B) {
 	objectType.Fields = map[string]*schema.FieldDefinition{
 		"string": {
 			Type: schema.StringType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				return "foo", nil
 			},
 		},
@@ -506,7 +506,7 @@ func BenchmarkExecuteRequest(b *testing.B) {
 					Type: schema.NewNonNullType(schema.IntType),
 				},
 			},
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return make([]struct{}, ctx.Arguments["count"].(int)), nil
 			},
 		},
@@ -549,7 +549,7 @@ func TestContextCancelation(t *testing.T) {
 	objectType.Fields = map[string]*schema.FieldDefinition{
 		"slowString": {
 			Type: schema.StringType,
-			Resolve: func(*schema.FieldContext) (interface{}, error) {
+			Resolve: func(schema.FieldContext) (interface{}, error) {
 				time.Sleep(100 * time.Millisecond)
 				return "foo", nil
 			},
@@ -561,7 +561,7 @@ func TestContextCancelation(t *testing.T) {
 					Type: schema.NewNonNullType(schema.IntType),
 				},
 			},
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return make([]struct{}, ctx.Arguments["count"].(int)), nil
 			},
 		},

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -59,7 +59,7 @@ type FieldCostContext = schema.FieldCostContext
 type FieldCost = schema.FieldCost
 
 // Returns a cost function which returns a constant resolver cost with no multiplier.
-func FieldResolverCost(n int) func(*FieldCostContext) FieldCost {
+func FieldResolverCost(n int) func(FieldCostContext) FieldCost {
 	return schema.FieldResolverCost(n)
 }
 

--- a/graphql/schema/field_definition.go
+++ b/graphql/schema/field_definition.go
@@ -35,8 +35,8 @@ type FieldCost struct {
 }
 
 // Returns a cost function which returns a constant resolver cost with no multiplier.
-func FieldResolverCost(n int) func(*FieldCostContext) FieldCost {
-	return func(*FieldCostContext) FieldCost {
+func FieldResolverCost(n int) func(FieldCostContext) FieldCost {
+	return func(FieldCostContext) FieldCost {
 		return FieldCost{
 			Resolver: n,
 		}
@@ -62,9 +62,9 @@ type FieldDefinition struct {
 	// This function can be used to define the cost of resolving the field. The total cost of an
 	// operation can be calculated before the operation is executed, enabling rate limiting and
 	// metering.
-	Cost func(*FieldCostContext) FieldCost
+	Cost func(FieldCostContext) FieldCost
 
-	Resolve func(*FieldContext) (interface{}, error)
+	Resolve func(FieldContext) (interface{}, error)
 }
 
 func (d *FieldDefinition) shallowValidate() error {

--- a/graphql/schema/introspection/introspection.go
+++ b/graphql/schema/introspection/introspection.go
@@ -21,7 +21,7 @@ var MetaFields = map[string]*schema.FieldDefinition{
 	"__schema": {
 		Type: schema.NewNonNullType(SchemaType),
 		Cost: schema.FieldResolverCost(0),
-		Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+		Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 			return ctx.Schema, nil
 		},
 	},
@@ -33,7 +33,7 @@ var MetaFields = map[string]*schema.FieldDefinition{
 				Type: schema.NewNonNullType(schema.StringType),
 			},
 		},
-		Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+		Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 			return ctx.Schema.NamedTypes()[ctx.Arguments["name"].(string)], nil
 		},
 	},
@@ -68,7 +68,7 @@ var SchemaType = &schema.ObjectType{
 		"types": {
 			Type: schema.NewNonNullType(schema.NewListType(schema.NewNonNullType(TypeType))),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				namedTypes := ctx.Schema.NamedTypes()
 				ret := make([]schema.Type, len(namedTypes))
 				i := 0
@@ -82,28 +82,28 @@ var SchemaType = &schema.ObjectType{
 		"queryType": {
 			Type: schema.NewNonNullType(TypeType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Schema.QueryType(), nil
 			},
 		},
 		"mutationType": {
 			Type: TypeType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Schema.MutationType(), nil
 			},
 		},
 		"subscriptionType": {
 			Type: TypeType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Schema.SubscriptionType(), nil
 			},
 		},
 		"directives": {
 			Type: schema.NewNonNullType(schema.NewListType(schema.NewNonNullType(DirectiveType))),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				directives := ctx.Schema.Directives()
 				ret := make([]directive, len(directives))
 				i := 0
@@ -172,7 +172,7 @@ func init() {
 		"kind": {
 			Type: schema.NewNonNullType(TypeKindType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				switch t := ctx.Object.(type) {
 				case *schema.ScalarType:
 					return typeKindScalar, nil
@@ -198,7 +198,7 @@ func init() {
 		"name": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				if t, ok := ctx.Object.(schema.NamedType); ok {
 					return t.TypeName(), nil
 				}
@@ -208,7 +208,7 @@ func init() {
 		"description": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				description := ""
 				switch t := ctx.Object.(type) {
 				case *schema.ScalarType:
@@ -236,7 +236,7 @@ func init() {
 					DefaultValue: false,
 				},
 			},
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				var fields map[string]*schema.FieldDefinition
 				switch t := ctx.Object.(type) {
 				case *schema.ObjectType:
@@ -262,7 +262,7 @@ func init() {
 		"interfaces": {
 			Type: schema.NewListType(schema.NewNonNullType(TypeType)),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				if t, ok := ctx.Object.(*schema.ObjectType); ok {
 					return t.ImplementedInterfaces, nil
 				}
@@ -272,7 +272,7 @@ func init() {
 		"possibleTypes": {
 			Type: schema.NewListType(schema.NewNonNullType(TypeType)),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				switch t := ctx.Object.(type) {
 				case *schema.InterfaceType:
 					return ctx.Schema.InterfaceImplementations(t.Name), nil
@@ -292,7 +292,7 @@ func init() {
 					DefaultValue: false,
 				},
 			},
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				if t, ok := ctx.Object.(*schema.EnumType); ok {
 					includeDeprecated := ctx.Arguments["includeDeprecated"].(bool)
 					ret := []enumValue{}
@@ -312,7 +312,7 @@ func init() {
 		"inputFields": {
 			Type: schema.NewListType(schema.NewNonNullType(InputValueType)),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				if t, ok := ctx.Object.(*schema.InputObjectType); ok {
 					return inputValues(t.Fields)
 				}
@@ -322,7 +322,7 @@ func init() {
 		"ofType": {
 			Type: TypeType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				switch t := ctx.Object.(type) {
 				case *schema.ListType:
 					return t.Type, nil
@@ -402,28 +402,28 @@ var DirectiveType = &schema.ObjectType{
 		"name": {
 			Type: schema.NewNonNullType(schema.StringType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(directive).Name, nil
 			},
 		},
 		"description": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return nullableString(ctx.Object.(directive).Definition.Description)
 			},
 		},
 		"locations": {
 			Type: schema.NewNonNullType(schema.NewListType(schema.NewNonNullType(DirectiveLocationType))),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(directive).Definition.Locations, nil
 			},
 		},
 		"args": {
 			Type: schema.NewNonNullType(schema.NewListType(schema.NewNonNullType(InputValueType))),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return inputValues(ctx.Object.(directive).Definition.Arguments)
 			},
 		},
@@ -441,42 +441,42 @@ var FieldType = &schema.ObjectType{
 		"name": {
 			Type: schema.NewNonNullType(schema.StringType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(field).Name, nil
 			},
 		},
 		"description": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return nullableString(ctx.Object.(field).Definition.Description)
 			},
 		},
 		"args": {
 			Type: schema.NewNonNullType(schema.NewListType(schema.NewNonNullType(InputValueType))),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return inputValues(ctx.Object.(field).Definition.Arguments)
 			},
 		},
 		"type": {
 			Type: schema.NewNonNullType(TypeType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(field).Definition.Type, nil
 			},
 		},
 		"isDeprecated": {
 			Type: schema.NewNonNullType(schema.BooleanType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(field).Definition.DeprecationReason != "", nil
 			},
 		},
 		"deprecationReason": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return nullableString(ctx.Object.(field).Definition.DeprecationReason)
 			},
 		},
@@ -494,28 +494,28 @@ var EnumValueType = &schema.ObjectType{
 		"name": {
 			Type: schema.NewNonNullType(schema.StringType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(enumValue).Name, nil
 			},
 		},
 		"description": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return nullableString(ctx.Object.(enumValue).Definition.Description)
 			},
 		},
 		"isDeprecated": {
 			Type: schema.NewNonNullType(schema.BooleanType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(enumValue).Definition.DeprecationReason != "", nil
 			},
 		},
 		"deprecationReason": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return nullableString(ctx.Object.(enumValue).Definition.DeprecationReason)
 			},
 		},
@@ -533,28 +533,28 @@ var InputValueType = &schema.ObjectType{
 		"name": {
 			Type: schema.NewNonNullType(schema.StringType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(inputValue).Name, nil
 			},
 		},
 		"description": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return nullableString(ctx.Object.(inputValue).Definition.Description)
 			},
 		},
 		"type": {
 			Type: schema.NewNonNullType(TypeType),
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				return ctx.Object.(inputValue).Definition.Type, nil
 			},
 		},
 		"defaultValue": {
 			Type: schema.StringType,
 			Cost: schema.FieldResolverCost(0),
-			Resolve: func(ctx *schema.FieldContext) (interface{}, error) {
+			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				def := ctx.Object.(inputValue).Definition
 				if v := def.DefaultValue; v != nil {
 					return marshalValue(def.Type, v)

--- a/graphql/validator/validate_cost.go
+++ b/graphql/validator/validate_cost.go
@@ -103,7 +103,7 @@ func ValidateCost(operationName string, variableValues map[string]interface{}, m
 							}
 							fieldCost := defaultCost
 							if def.Cost != nil {
-								fieldCost = def.Cost(&costContext)
+								fieldCost = def.Cost(costContext)
 							}
 							cost = checkedNonNegativeAdd(cost, checkedNonNegativeMultiply(multiplier, fieldCost.Resolver))
 							if fieldCost.Multiplier > 1 {

--- a/graphql/validator/validator_test.go
+++ b/graphql/validator/validator_test.go
@@ -197,7 +197,7 @@ func init() {
 					DefaultValue: 10,
 				},
 			},
-			Cost: func(ctx *schema.FieldCostContext) schema.FieldCost {
+			Cost: func(ctx schema.FieldCostContext) schema.FieldCost {
 				cost, _ := ctx.Arguments["cost"].(int)
 				return schema.FieldCost{
 					Resolver: cost,
@@ -211,7 +211,7 @@ func init() {
 					Type: schema.IntType,
 				},
 			},
-			Cost: func(ctx *schema.FieldCostContext) schema.FieldCost {
+			Cost: func(ctx schema.FieldCostContext) schema.FieldCost {
 				cost, _ := ctx.Arguments["cost"].(int)
 				return schema.FieldCost{
 					Context: context.WithValue(ctx.Context, costContextKey, cost),
@@ -220,7 +220,7 @@ func init() {
 		},
 		"costFromContext": {
 			Type: schema.IntType,
-			Cost: func(ctx *schema.FieldCostContext) schema.FieldCost {
+			Cost: func(ctx schema.FieldCostContext) schema.FieldCost {
 				return schema.FieldCost{
 					Resolver: ctx.Context.Value(costContextKey).(int),
 				}
@@ -233,7 +233,7 @@ func init() {
 					Type: schema.IntType,
 				},
 			},
-			Cost: func(ctx *schema.FieldCostContext) schema.FieldCost {
+			Cost: func(ctx schema.FieldCostContext) schema.FieldCost {
 				multiplier, _ := ctx.Arguments["first"].(int)
 				return schema.FieldCost{
 					Resolver:   1,

--- a/graphqlws_test.go
+++ b/graphqlws_test.go
@@ -24,14 +24,14 @@ func TestGraphQLWS(t *testing.T) {
 
 	testCfg.AddQueryField("foo", &graphql.FieldDefinition{
 		Type: graphql.BooleanType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return true, nil
 		},
 	})
 
 	testCfg.AddSubscription("time", &graphql.FieldDefinition{
 		Type: graphql.NewNonNullType(DateTimeType),
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			if ctx.IsSubscribe {
 				ticker := time.NewTicker(time.Second)
 				return &SubscriptionSourceStream{
@@ -144,7 +144,7 @@ func TestGraphQLWS_InitParameters(t *testing.T) {
 
 	testCfg.AddQueryField("whoami", &graphql.FieldDefinition{
 		Type: graphql.StringType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return ctx.Context.Value("name"), nil
 		},
 	})
@@ -256,14 +256,14 @@ func TestGraphQLWSTransport(t *testing.T) {
 
 	testCfg.AddQueryField("foo", &graphql.FieldDefinition{
 		Type: graphql.BooleanType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return true, nil
 		},
 	})
 
 	testCfg.AddSubscription("time", &graphql.FieldDefinition{
 		Type: graphql.NewNonNullType(DateTimeType),
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			if ctx.IsSubscribe {
 				ticker := time.NewTicker(time.Second)
 				return &SubscriptionSourceStream{
@@ -373,7 +373,7 @@ func TestGraphQLTransportWS_InitParameters(t *testing.T) {
 
 	testCfg.AddQueryField("whoami", &graphql.FieldDefinition{
 		Type: graphql.StringType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			return ctx.Context.Value("name"), nil
 		},
 	})

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -24,7 +24,7 @@ func TestConnection(t *testing.T) {
 		EdgeFields: map[string]*graphql.FieldDefinition{
 			"node": {
 				Type: graphql.IntType,
-				Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+				Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 					return ctx.Object, nil
 				},
 			},
@@ -34,7 +34,7 @@ func TestConnection(t *testing.T) {
 
 	config.AddQueryField("connection", Connection(&ConnectionConfig{
 		NamePrefix: "Test",
-		ResolveEdges: func(ctx *graphql.FieldContext, after, before interface{}, limit int) (edgeSlice interface{}, cursorLess func(a, b interface{}) bool, err error) {
+		ResolveEdges: func(ctx graphql.FieldContext, after, before interface{}, limit int) (edgeSlice interface{}, cursorLess func(a, b interface{}) bool, err error) {
 			ret := make([]int, limit)
 			for i := range ret {
 				ret[i] = i
@@ -43,7 +43,7 @@ func TestConnection(t *testing.T) {
 				return false
 			}, nil
 		},
-		ResolveTotalCount: func(ctx *graphql.FieldContext) (interface{}, error) {
+		ResolveTotalCount: func(ctx graphql.FieldContext) (interface{}, error) {
 			return 1000, nil
 		},
 		CursorType: reflect.TypeOf(""),
@@ -53,7 +53,7 @@ func TestConnection(t *testing.T) {
 		EdgeFields: map[string]*graphql.FieldDefinition{
 			"node": {
 				Type: graphql.IntType,
-				Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+				Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 					return ctx.Object, nil
 				},
 			},
@@ -175,10 +175,10 @@ func TestConnection_ZeroArg_WithoutPageInfo(t *testing.T) {
 	config := &Config{}
 	config.AddQueryField("connection", Connection(&ConnectionConfig{
 		NamePrefix: "Test",
-		ResolveEdges: func(ctx *graphql.FieldContext, after, before interface{}, limit int) (edgeSlice interface{}, cursorLess func(a, b interface{}) bool, err error) {
+		ResolveEdges: func(ctx graphql.FieldContext, after, before interface{}, limit int) (edgeSlice interface{}, cursorLess func(a, b interface{}) bool, err error) {
 			return nil, nil, fmt.Errorf("the edge resolver should not be invoked")
 		},
-		ResolveTotalCount: func(ctx *graphql.FieldContext) (interface{}, error) {
+		ResolveTotalCount: func(ctx graphql.FieldContext) (interface{}, error) {
 			return 1000, nil
 		},
 		CursorType: reflect.TypeOf(""),
@@ -188,7 +188,7 @@ func TestConnection_ZeroArg_WithoutPageInfo(t *testing.T) {
 		EdgeFields: map[string]*graphql.FieldDefinition{
 			"node": {
 				Type: graphql.IntType,
-				Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+				Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 					return ctx.Object, nil
 				},
 			},
@@ -228,14 +228,14 @@ func TestConnection_ZeroArg_WithPageInfo(t *testing.T) {
 	config := &Config{}
 	config.AddQueryField("connection", Connection(&ConnectionConfig{
 		NamePrefix: "Test",
-		ResolveEdges: func(ctx *graphql.FieldContext, after, before interface{}, limit int) (edgeSlice interface{}, cursorLess func(a, b interface{}) bool, err error) {
+		ResolveEdges: func(ctx graphql.FieldContext, after, before interface{}, limit int) (edgeSlice interface{}, cursorLess func(a, b interface{}) bool, err error) {
 			return Go(ctx.Context, func() (interface{}, error) {
 					return make([]int, limit), nil
 				}), func(a, b interface{}) bool {
 					return false
 				}, nil
 		},
-		ResolveTotalCount: func(ctx *graphql.FieldContext) (interface{}, error) {
+		ResolveTotalCount: func(ctx graphql.FieldContext) (interface{}, error) {
 			return 1000, nil
 		},
 		CursorType: reflect.TypeOf(""),
@@ -245,7 +245,7 @@ func TestConnection_ZeroArg_WithPageInfo(t *testing.T) {
 		EdgeFields: map[string]*graphql.FieldDefinition{
 			"node": {
 				Type: graphql.IntType,
-				Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+				Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 					return ctx.Object, nil
 				},
 			},
@@ -306,7 +306,7 @@ func TestTimeBasedConnection(t *testing.T) {
 				Type: graphql.BooleanType,
 			},
 		},
-		EdgeGetter: func(ctx *graphql.FieldContext, minTime time.Time, maxTime time.Time, limit int) (interface{}, error) {
+		EdgeGetter: func(ctx graphql.FieldContext, minTime time.Time, maxTime time.Time, limit int) (interface{}, error) {
 			var ret []time.Time
 			for _, edge := range edges {
 				if !edge.Before(minTime) && !edge.After(maxTime) {
@@ -326,7 +326,7 @@ func TestTimeBasedConnection(t *testing.T) {
 		EdgeFields: map[string]*graphql.FieldDefinition{
 			"node": {
 				Type: DateTimeType,
-				Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+				Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 					return ctx.Object, nil
 				},
 			},

--- a/scalars.go
+++ b/scalars.go
@@ -51,7 +51,7 @@ var DateTimeType = &graphql.ScalarType{
 func NonZeroDateTime(fieldName string) *graphql.FieldDefinition {
 	return &graphql.FieldDefinition{
 		Type: DateTimeType,
-		Resolve: func(ctx *graphql.FieldContext) (interface{}, error) {
+		Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 			if t := fieldValue(ctx.Object, fieldName).(time.Time); !t.IsZero() {
 				return t, nil
 			}


### PR DESCRIPTION
## What it Does

This is a breaking change to make resolvers take a `FieldContext` argument instead of a `*FieldContext`.

Just removing the pointer is a significant improvement in performance:

Before:

```
% go test -v ./graphql/executor -bench=BenchmarkExecuteRequest -run asdqweqwe -benchtime 5s
goos: darwin
goarch: arm64
pkg: github.com/ccbrown/api-fu/graphql/executor
BenchmarkExecuteRequest
BenchmarkExecuteRequest-10    	    5815	    876965 ns/op	  796542 B/op	   20444 allocs/op
```

After:

```
% go test -v ./graphql/executor -bench=BenchmarkExecuteRequest -run asdqweqwe -benchtime 5s
goos: darwin
goarch: arm64
pkg: github.com/ccbrown/api-fu/graphql/executor
BenchmarkExecuteRequest
BenchmarkExecuteRequest-10    	    7444	    806404 ns/op	  665852 B/op	   18402 allocs/op
```

That's a big improvement in allocations and almost a 10% improvement in speed.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...` and see above for benchmark command.

<!-- Does running this require any special setup or dependencies? -->
