### PR TITLE
optimize path tracking

### DIFF
--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -499,6 +499,12 @@ func BenchmarkExecuteRequest(b *testing.B) {
 				return "foo", nil
 			},
 		},
+		"nonNullString": {
+			Type: schema.NewNonNullType(schema.StringType),
+			Resolve: func(schema.FieldContext) (interface{}, error) {
+				return "foo", nil
+			},
+		},
 		"objects": {
 			Type: schema.NewListType(objectType),
 			Arguments: map[string]*schema.InputValueDefinition{
@@ -520,8 +526,10 @@ func BenchmarkExecuteRequest(b *testing.B) {
 		string
 		objects(count: 20) {
 			string
+			nonNullString
 			objects(count: 100) {
 				string
+				nonNullString
 			}
 		}
 	}`))


### PR DESCRIPTION
## What it Does

Optimizations to avoid unnecessary map and path component allocations.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...` and benchmark.

Before:

```
BenchmarkExecuteRequest
BenchmarkExecuteRequest-10    	    5780	    870531 ns/op	  696117 B/op	   16337 allocs/op
```

After:

```
BenchmarkExecuteRequest
BenchmarkExecuteRequest-10    	    8518	    707175 ns/op	  469875 B/op	   10277 allocs/op
```

<!-- Does running this require any special setup or dependencies? -->
