### PR TITLE
handle panics when TimeBasedConnection EdgeGetter returns nil, nil

### DIFF
--- a/pagination.go
+++ b/pagination.go
@@ -645,6 +645,9 @@ func TimeBasedConnection(config *TimeBasedConnectionConfig) *graphql.FieldDefini
 					promises = append(promises, promise)
 				} else {
 					v := reflect.ValueOf(queryEdges)
+					if v.Kind() == reflect.Invalid || v.IsNil() {
+						continue
+					}
 					for i := 0; i < v.Len(); i++ {
 						edges = append(edges, v.Index(i).Interface())
 					}

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -307,6 +307,9 @@ func TestTimeBasedConnection(t *testing.T) {
 			},
 		},
 		EdgeGetter: func(ctx graphql.FieldContext, minTime time.Time, maxTime time.Time, limit int) (interface{}, error) {
+			if limit == 0 {
+				return nil, nil
+			}
 			var ret []time.Time
 			for _, edge := range edges {
 				if !edge.Before(minTime) && !edge.After(maxTime) {
@@ -472,6 +475,22 @@ func TestTimeBasedConnection(t *testing.T) {
 							{"node":"2020-01-01T00:00:02Z"},
 							{"node":"2020-01-01T00:00:03Z"}
 						]
+					}
+				}
+			}`,
+		},
+		"Empty": {
+			Query: `{
+				connection(last: 0, before: "") {
+					edges {
+						node
+					}
+				}
+			}`,
+			ExpectedJSON: `{
+				"data":{
+					"connection":{
+						"edges":[]
 					}
 				}
 			}`,


### PR DESCRIPTION
fixes panics when returning nil, nil instead of an empty slice of T
