### PR TITLE
Add mechanism to dynamically control visibility of fields and types

### DIFF
--- a/graphql/schema/enum_type.go
+++ b/graphql/schema/enum_type.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ccbrown/api-fu/graphql/ast"
@@ -11,6 +12,10 @@ type EnumType struct {
 	Description string
 	Directives  []*Directive
 	Values      map[string]*EnumValueDefinition
+
+	// If given, this type will only be visible via introspection if the given function returns
+	// true. This can for example be used to build APIs that are gated behind feature flags.
+	IsVisible func(context.Context) bool
 }
 
 type EnumValueDefinition struct {
@@ -42,6 +47,13 @@ func (t *EnumType) IsSameType(other Type) bool {
 
 func (t *EnumType) TypeName() string {
 	return t.Name
+}
+
+func (t *EnumType) IsTypeVisible(ctx context.Context) bool {
+	if t.IsVisible == nil {
+		return true
+	}
+	return t.IsVisible(ctx)
 }
 
 func (t *EnumType) shallowValidate() error {

--- a/graphql/schema/field_definition.go
+++ b/graphql/schema/field_definition.go
@@ -59,6 +59,10 @@ type FieldDefinition struct {
 	Directives        []*Directive
 	DeprecationReason string
 
+	// If given, this field will only be visible and usable if the given function returns true. This
+	// can for example be used to build APIs that are gated behind feature flags.
+	IsVisible func(context.Context) bool
+
 	// This function can be used to define the cost of resolving the field. The total cost of an
 	// operation can be calculated before the operation is executed, enabling rate limiting and
 	// metering.

--- a/graphql/schema/input_object_type.go
+++ b/graphql/schema/input_object_type.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -25,6 +26,10 @@ type InputObjectType struct {
 	// For most use-cases, this function is optional. If it is required, but nil, you will get an
 	// error when you attempt to create the schema.
 	ResultCoercion func(interface{}) (map[string]interface{}, error)
+
+	// If given, this type will only be visible via introspection if the given function returns
+	// true. This can for example be used to build APIs that are gated behind feature flags.
+	IsVisible func(context.Context) bool
 }
 
 func (t *InputObjectType) String() string {
@@ -49,6 +54,13 @@ func (t *InputObjectType) IsSameType(other Type) bool {
 
 func (t *InputObjectType) TypeName() string {
 	return t.Name
+}
+
+func (t *InputObjectType) IsTypeVisible(ctx context.Context) bool {
+	if t.IsVisible == nil {
+		return true
+	}
+	return t.IsVisible(ctx)
 }
 
 func (t *InputObjectType) CoerceVariableValue(v interface{}) (interface{}, error) {

--- a/graphql/schema/interface_type.go
+++ b/graphql/schema/interface_type.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -10,6 +11,10 @@ type InterfaceType struct {
 	Description string
 	Directives  []*Directive
 	Fields      map[string]*FieldDefinition
+
+	// If given, this type will only be visible via introspection if the given function returns
+	// true. This can for example be used to build APIs that are gated behind feature flags.
+	IsVisible func(context.Context) bool
 }
 
 func (t *InterfaceType) String() string {
@@ -34,6 +39,13 @@ func (t *InterfaceType) IsSameType(other Type) bool {
 
 func (t *InterfaceType) TypeName() string {
 	return t.Name
+}
+
+func (t *InterfaceType) IsTypeVisible(ctx context.Context) bool {
+	if t.IsVisible == nil {
+		return true
+	}
+	return t.IsVisible(ctx)
 }
 
 func (t *InterfaceType) shallowValidate() error {

--- a/graphql/schema/object_type.go
+++ b/graphql/schema/object_type.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -16,6 +17,10 @@ type ObjectType struct {
 	// Objects that implement one or more interfaces must define this. The function should return
 	// true if obj is an object of this type.
 	IsTypeOf func(obj interface{}) bool
+
+	// If given, this type will only be visible via introspection if the given function returns
+	// true. This can for example be used to build APIs that are gated behind feature flags.
+	IsVisible func(context.Context) bool
 }
 
 func (t *ObjectType) String() string {
@@ -55,6 +60,13 @@ func (t *ObjectType) IsSameType(other Type) bool {
 
 func (t *ObjectType) TypeName() string {
 	return t.Name
+}
+
+func (t *ObjectType) IsTypeVisible(ctx context.Context) bool {
+	if t.IsVisible == nil {
+		return true
+	}
+	return t.IsVisible(ctx)
 }
 
 func (t *ObjectType) satisfyInterface(iface *InterfaceType) error {

--- a/graphql/schema/scalar_type.go
+++ b/graphql/schema/scalar_type.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ccbrown/api-fu/graphql/ast"
@@ -20,6 +21,10 @@ type ScalarType struct {
 	// Should return nil if coercion is impossible. In many cases, this can be the same as
 	// VariableValueCoercion.
 	ResultCoercion func(interface{}) interface{}
+
+	// If given, this type will only be visible via introspection if the given function returns
+	// true. This can for example be used to build APIs that are gated behind feature flags.
+	IsVisible func(context.Context) bool
 }
 
 func (t *ScalarType) String() string {
@@ -44,6 +49,13 @@ func (t *ScalarType) IsSameType(other Type) bool {
 
 func (t *ScalarType) TypeName() string {
 	return t.Name
+}
+
+func (t *ScalarType) IsTypeVisible(ctx context.Context) bool {
+	if t.IsVisible == nil {
+		return true
+	}
+	return t.IsVisible(ctx)
 }
 
 func (t *ScalarType) CoerceVariableValue(v interface{}) (interface{}, error) {

--- a/graphql/schema/schema.go
+++ b/graphql/schema/schema.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -147,6 +148,7 @@ type Type interface {
 type NamedType interface {
 	Type
 	TypeName() string
+	IsTypeVisible(context.Context) bool
 }
 
 type WrappedType interface {

--- a/graphql/schema/union_type.go
+++ b/graphql/schema/union_type.go
@@ -1,12 +1,19 @@
 package schema
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 type UnionType struct {
 	Name        string
 	Description string
 	Directives  []*Directive
 	MemberTypes []*ObjectType
+
+	// If given, this type will only be visible via introspection if the given function returns
+	// true. This can for example be used to build APIs that are gated behind feature flags.
+	IsVisible func(context.Context) bool
 }
 
 func (d *UnionType) String() string {
@@ -31,6 +38,13 @@ func (d *UnionType) IsSameType(other Type) bool {
 
 func (d *UnionType) TypeName() string {
 	return d.Name
+}
+
+func (t *UnionType) IsTypeVisible(ctx context.Context) bool {
+	if t.IsVisible == nil {
+		return true
+	}
+	return t.IsVisible(ctx)
 }
 
 func (d *UnionType) shallowValidate() error {


### PR DESCRIPTION
## What it Does

This enables users to implement feature flagging as described in https://github.com/graphql/graphql-wg/blob/main/rfcs/OptInFeatures.md by defining functions on field and type definitions which control their visibility.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
