### PR TITLE
allow graphql types and fields to be gated behind feature flags

### DIFF
--- a/api.go
+++ b/api.go
@@ -234,10 +234,13 @@ func (api *API) ServeGraphQL(w http.ResponseWriter, r *http.Request) {
 	}
 	req.Schema = api.schema
 	req.IdleHandler = apiRequest.IdleHandler
+	if api.config.Features != nil {
+		req.Features = api.config.Features(ctx)
+	}
 
 	execute := func(req *graphql.Request) *graphql.Response {
 		var info RequestInfo
-		if doc, errs := graphql.ParseAndValidate(req.Query, req.Schema, req.ValidateCost(-1, &info.Cost, api.config.DefaultFieldCost)); len(errs) > 0 {
+		if doc, errs := graphql.ParseAndValidate(req.Query, req.Schema, req.Features, req.ValidateCost(-1, &info.Cost, api.config.DefaultFieldCost)); len(errs) > 0 {
 			return &graphql.Response{
 				Errors: errs,
 			}

--- a/cmd/gql-client-gen/main.go
+++ b/cmd/gql-client-gen/main.go
@@ -254,7 +254,7 @@ func generateTypeDef(name, original string) string {
 
 func (s *generateState) processQuery(q string) []error {
 	var ret []error
-	doc, errs := graphql.ParseAndValidate(q, s.schema)
+	doc, errs := graphql.ParseAndValidate(q, s.schema, nil)
 	if len(errs) > 0 {
 		for _, err := range errs {
 			ret = append(ret, err)

--- a/config.go
+++ b/config.go
@@ -51,6 +51,9 @@ type Config struct {
 	// documentation.
 	PreprocessGraphQLSchemaDefinition func(schema *graphql.SchemaDefinition) error
 
+	// If given, this function will be invoked to get the feature set for a request.
+	Features func(ctx context.Context) graphql.FeatureSet
+
 	initOnce      sync.Once
 	nodeInterface *graphql.InterfaceType
 	query         *graphql.ObjectType

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -91,7 +91,7 @@ func newExecutor(ctx context.Context, r *Request) (*executor, *Error) {
 	if err != nil {
 		return nil, err
 	}
-	coercedVariableValues, err := coerceVariableValues(r.Schema, operation, r.VariableValues)
+	coercedVariableValues, err := coerceVariableValues(r.Schema, r.Features, operation, r.VariableValues)
 	if err != nil {
 		return nil, err
 	}
@@ -611,8 +611,8 @@ func schemaType(t ast.Type, s *schema.Schema) schema.Type {
 	return nil
 }
 
-func coerceVariableValues(s *schema.Schema, operation *ast.OperationDefinition, variableValues map[string]any) (map[string]any, *Error) {
-	ret, err := validator.CoerceVariableValues(s, operation, variableValues)
+func coerceVariableValues(s *schema.Schema, features schema.FeatureSet, operation *ast.OperationDefinition, variableValues map[string]any) (map[string]any, *Error) {
+	ret, err := validator.CoerceVariableValues(s, features, operation, variableValues)
 	return ret, newErrorWithValidatorError(err)
 }
 

--- a/graphql/executor/executor.go
+++ b/graphql/executor/executor.go
@@ -32,6 +32,7 @@ type Request struct {
 	Schema         *schema.Schema
 	OperationName  string
 	VariableValues map[string]any
+	Features       schema.FeatureSet
 	InitialValue   any
 	IdleHandler    func()
 }
@@ -72,6 +73,7 @@ type executor struct {
 	Schema              *schema.Schema
 	FragmentDefinitions map[string]*ast.FragmentDefinition
 	VariableValues      map[string]any
+	Features            schema.FeatureSet
 	Errors              []*Error
 	Operation           *ast.OperationDefinition
 	IdleHandler         func()
@@ -99,6 +101,7 @@ func newExecutor(ctx context.Context, r *Request) (*executor, *Error) {
 		Schema:               r.Schema,
 		FragmentDefinitions:  map[string]*ast.FragmentDefinition{},
 		VariableValues:       coercedVariableValues,
+		Features:             r.Features,
 		Operation:            operation,
 		IdleHandler:          r.IdleHandler,
 		GroupedFieldSetCache: map[string]*GroupedFieldSet{},
@@ -162,7 +165,7 @@ func (e *executor) subscribe(initialValue any) (any, *Error) {
 	fields := item.Fields
 	field := fields[0]
 	fieldName := field.Name.Name
-	fieldDef := subscriptionType.Fields[fieldName]
+	fieldDef := subscriptionType.GetField(fieldName, e.Features)
 	if fieldDef == nil {
 		return nil, newError(field, "Undefined root subscription field.")
 	}
@@ -175,6 +178,7 @@ func (e *executor) subscribe(initialValue any) (any, *Error) {
 		Context:     e.Context,
 		Schema:      e.Schema,
 		Object:      initialValue,
+		Features:    e.Features,
 		Arguments:   argumentValues,
 		IsSubscribe: true,
 	})
@@ -248,7 +252,7 @@ func (e *executor) executeSelections(selections []ast.Selection, objectType *sch
 			continue
 		}
 
-		fieldDef := objectType.Fields[fieldName]
+		fieldDef := objectType.GetField(fieldName, e.Features)
 		if fieldDef == nil && objectType == e.Schema.QueryType() {
 			fieldDef = introspection.MetaFields[fieldName]
 		}
@@ -319,6 +323,7 @@ func (e *executor) executeField(objectValue any, fields []*ast.Field, fieldDef *
 		Context:   e.Context,
 		Schema:    e.Schema,
 		Object:    objectValue,
+		Features:  e.Features,
 		Arguments: argumentValues,
 	})
 	if !isNil(err) {

--- a/graphql/executor/executor_test.go
+++ b/graphql/executor/executor_test.go
@@ -229,7 +229,7 @@ func TestSubscribe(t *testing.T) {
 	require.NoError(t, err)
 	doc, parseErrs := parser.ParseDocument([]byte(`subscription {int}`))
 	require.Empty(t, parseErrs)
-	require.Empty(t, validator.ValidateDocument(doc, s))
+	require.Empty(t, validator.ValidateDocument(doc, s, nil))
 
 	assert.True(t, IsSubscription(doc, ""))
 
@@ -262,7 +262,7 @@ func TestExecuteRequest(t *testing.T) {
 	t.Run("IntrospectionQuery", func(t *testing.T) {
 		parsed, parseErrs := parser.ParseDocument(introspection.Query)
 		require.Empty(t, parseErrs)
-		require.Empty(t, validator.ValidateDocument(parsed, s))
+		require.Empty(t, validator.ValidateDocument(parsed, s, nil))
 		_, errs := ExecuteRequest(context.Background(), &Request{
 			Document: parsed,
 			Schema:   s,
@@ -419,7 +419,7 @@ func TestExecuteRequest(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			parsed, parseErrs := parser.ParseDocument([]byte(tc.Document))
 			require.Empty(t, parseErrs)
-			require.Empty(t, validator.ValidateDocument(parsed, s))
+			require.Empty(t, validator.ValidateDocument(parsed, s, nil))
 			data, errs := ExecuteRequest(context.Background(), &Request{
 				Document:       parsed,
 				Schema:         s,
@@ -534,7 +534,7 @@ func BenchmarkExecuteRequest(b *testing.B) {
 		}
 	}`))
 	require.Empty(b, parseErrs)
-	require.Empty(b, validator.ValidateDocument(doc, s))
+	require.Empty(b, validator.ValidateDocument(doc, s, nil))
 
 	r := &Request{
 		Document: doc,
@@ -585,7 +585,7 @@ func TestContextCancelation(t *testing.T) {
 		}
 	}`))
 	require.Empty(t, parseErrs)
-	require.Empty(t, validator.ValidateDocument(doc, s))
+	require.Empty(t, validator.ValidateDocument(doc, s, nil))
 
 	r := &Request{
 		Document: doc,

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -180,6 +180,7 @@ func (r *Request) executorRequest(doc *ast.Document) *executor.Request {
 		Schema:         r.Schema,
 		OperationName:  r.OperationName,
 		VariableValues: r.VariableValues,
+		Features:       r.Features,
 		InitialValue:   r.InitialValue,
 		IdleHandler:    r.IdleHandler,
 	}

--- a/graphql/schema/enum_type.go
+++ b/graphql/schema/enum_type.go
@@ -11,6 +11,9 @@ type EnumType struct {
 	Description string
 	Directives  []*Directive
 	Values      map[string]*EnumValueDefinition
+
+	// This type is only available for introspection and use when the given features are enabled.
+	RequiredFeatures FeatureSet
 }
 
 type EnumValueDefinition struct {
@@ -38,6 +41,10 @@ func (t *EnumType) IsSubTypeOf(other Type) bool {
 
 func (t *EnumType) IsSameType(other Type) bool {
 	return t == other
+}
+
+func (t *EnumType) TypeRequiredFeatures() FeatureSet {
+	return t.RequiredFeatures
 }
 
 func (t *EnumType) TypeName() string {

--- a/graphql/schema/feature_set.go
+++ b/graphql/schema/feature_set.go
@@ -1,0 +1,25 @@
+package schema
+
+type FeatureSet map[string]struct{}
+
+func NewFeatureSet(features ...string) FeatureSet {
+	fs := make(FeatureSet, len(features))
+	for _, feature := range features {
+		fs[feature] = struct{}{}
+	}
+	return fs
+}
+
+func (s FeatureSet) Has(feature string) bool {
+	_, ok := s[feature]
+	return ok
+}
+
+func (s FeatureSet) IsSubsetOf(other FeatureSet) bool {
+	for feature := range s {
+		if _, ok := other[feature]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/graphql/schema/feature_set_test.go
+++ b/graphql/schema/feature_set_test.go
@@ -1,0 +1,32 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureSet(t *testing.T) {
+	s := NewFeatureSet("a", "b", "c")
+	assert.True(t, s.Has("a"))
+	assert.True(t, s.Has("b"))
+	assert.True(t, s.Has("c"))
+	assert.False(t, s.Has("d"))
+
+	s2 := NewFeatureSet("a", "b")
+	assert.True(t, s2.IsSubsetOf(s))
+	assert.False(t, s.IsSubsetOf(s2))
+}
+
+func TestFeatureSet_Nil(t *testing.T) {
+	var s FeatureSet
+	assert.False(t, s.Has("a"))
+
+	s2 := NewFeatureSet("a", "b")
+	assert.True(t, s.IsSubsetOf(s2))
+	assert.False(t, s2.IsSubsetOf(s))
+
+	var s3 FeatureSet
+	assert.True(t, s.IsSubsetOf(s3))
+	assert.True(t, s3.IsSubsetOf(s))
+}

--- a/graphql/schema/field_definition.go
+++ b/graphql/schema/field_definition.go
@@ -11,6 +11,7 @@ type FieldContext struct {
 	Context   context.Context
 	Schema    *Schema
 	Object    interface{}
+	Features  FeatureSet
 	Arguments map[string]interface{}
 
 	// IsSubscribe is true if this is a subscription field being invoked for a subscribe operation.
@@ -58,6 +59,9 @@ type FieldDefinition struct {
 	Type              Type
 	Directives        []*Directive
 	DeprecationReason string
+
+	// This field is only available for introspection and use when the given features are enabled.
+	RequiredFeatures FeatureSet
 
 	// This function can be used to define the cost of resolving the field. The total cost of an
 	// operation can be calculated before the operation is executed, enabling rate limiting and

--- a/graphql/schema/field_definition.go
+++ b/graphql/schema/field_definition.go
@@ -76,10 +76,14 @@ func (d *FieldDefinition) shallowValidate() error {
 		return fmt.Errorf("field is missing type")
 	} else if !d.Type.IsOutputType() {
 		return fmt.Errorf("%v cannot be used as a field type", d.Type)
+	} else if !d.Type.TypeRequiredFeatures().IsSubsetOf(d.RequiredFeatures) {
+		return fmt.Errorf("field type requires features that are not required by the field")
 	} else {
-		for name := range d.Arguments {
+		for name, arg := range d.Arguments {
 			if !isName(name) || strings.HasPrefix(name, "__") {
 				return fmt.Errorf("illegal field argument name: %v", name)
+			} else if !arg.Type.TypeRequiredFeatures().IsSubsetOf(d.RequiredFeatures) {
+				return fmt.Errorf("field argument %v requires features that are not required by the field", name)
 			}
 		}
 	}

--- a/graphql/schema/interface_type.go
+++ b/graphql/schema/interface_type.go
@@ -10,6 +10,9 @@ type InterfaceType struct {
 	Description string
 	Directives  []*Directive
 	Fields      map[string]*FieldDefinition
+
+	// This type is only available for introspection and use when the given features are enabled.
+	RequiredFeatures FeatureSet
 }
 
 func (t *InterfaceType) GetField(name string, features FeatureSet) *FieldDefinition {
@@ -39,6 +42,10 @@ func (t *InterfaceType) IsSameType(other Type) bool {
 	return t == other
 }
 
+func (t *InterfaceType) TypeRequiredFeatures() FeatureSet {
+	return t.RequiredFeatures
+}
+
 func (t *InterfaceType) TypeName() string {
 	return t.Name
 }
@@ -49,7 +56,7 @@ func (t *InterfaceType) shallowValidate() error {
 		if !isName(name) || strings.HasPrefix(name, "__") {
 			return fmt.Errorf("illegal field name: %v", name)
 		}
-		if len(field.RequiredFeatures) == 0 {
+		if field.RequiredFeatures.IsSubsetOf(t.RequiredFeatures) {
 			hasAtLeastOneUnconditionalField = true
 		}
 	}

--- a/graphql/schema/interface_type.go
+++ b/graphql/schema/interface_type.go
@@ -12,6 +12,13 @@ type InterfaceType struct {
 	Fields      map[string]*FieldDefinition
 }
 
+func (t *InterfaceType) GetField(name string, features FeatureSet) *FieldDefinition {
+	if field, ok := t.Fields[name]; ok && field.RequiredFeatures.IsSubsetOf(features) {
+		return field
+	}
+	return nil
+}
+
 func (t *InterfaceType) String() string {
 	return t.Name
 }

--- a/graphql/schema/interface_type.go
+++ b/graphql/schema/interface_type.go
@@ -44,14 +44,17 @@ func (t *InterfaceType) TypeName() string {
 }
 
 func (t *InterfaceType) shallowValidate() error {
-	if len(t.Fields) == 0 {
-		return fmt.Errorf("%v must have at least one field", t.Name)
-	} else {
-		for name := range t.Fields {
-			if !isName(name) || strings.HasPrefix(name, "__") {
-				return fmt.Errorf("illegal field name: %v", name)
-			}
+	hasAtLeastOneUnconditionalField := false
+	for name, field := range t.Fields {
+		if !isName(name) || strings.HasPrefix(name, "__") {
+			return fmt.Errorf("illegal field name: %v", name)
 		}
+		if len(field.RequiredFeatures) == 0 {
+			hasAtLeastOneUnconditionalField = true
+		}
+	}
+	if !hasAtLeastOneUnconditionalField {
+		return fmt.Errorf("%v must have at least one field", t.Name)
 	}
 	return nil
 }

--- a/graphql/schema/introspection/introspection.go
+++ b/graphql/schema/introspection/introspection.go
@@ -249,7 +249,7 @@ func init() {
 				includeDeprecated := ctx.Arguments["includeDeprecated"].(bool)
 				ret := []field{}
 				for name, def := range fields {
-					if def.DeprecationReason == "" || includeDeprecated {
+					if (def.DeprecationReason == "" || includeDeprecated) && def.RequiredFeatures.IsSubsetOf(ctx.Features) {
 						ret = append(ret, field{
 							Name:       name,
 							Definition: def,

--- a/graphql/schema/introspection/introspection.go
+++ b/graphql/schema/introspection/introspection.go
@@ -70,11 +70,11 @@ var SchemaType = &schema.ObjectType{
 			Cost: schema.FieldResolverCost(0),
 			Resolve: func(ctx schema.FieldContext) (interface{}, error) {
 				namedTypes := ctx.Schema.NamedTypes()
-				ret := make([]schema.Type, len(namedTypes))
-				i := 0
+				ret := make([]schema.Type, 0, len(namedTypes))
 				for _, def := range namedTypes {
-					ret[i] = def
-					i++
+					if def.TypeRequiredFeatures().IsSubsetOf(ctx.Features) {
+						ret = append(ret, def)
+					}
 				}
 				return ret, nil
 			},

--- a/graphql/schema/introspection/schema_data_test.go
+++ b/graphql/schema/introspection/schema_data_test.go
@@ -41,7 +41,7 @@ func TestSchemaData(t *testing.T) {
 			}
 		`
 
-		doc, errs := graphql.ParseAndValidate(query, schema)
+		doc, errs := graphql.ParseAndValidate(query, schema, nil)
 		require.Empty(t, errs)
 		assert.NotNil(t, doc)
 	})
@@ -56,7 +56,7 @@ func TestSchemaData(t *testing.T) {
 			}
 		`
 
-		_, errs := graphql.ParseAndValidate(query, schema)
+		_, errs := graphql.ParseAndValidate(query, schema, nil)
 		assert.NotEmpty(t, errs)
 	})
 
@@ -70,7 +70,7 @@ func TestSchemaData(t *testing.T) {
 			}
 		`
 
-		_, errs := graphql.ParseAndValidate(query, schema)
+		_, errs := graphql.ParseAndValidate(query, schema, nil)
 		assert.Empty(t, errs)
 	})
 }

--- a/graphql/schema/list_type.go
+++ b/graphql/schema/list_type.go
@@ -42,6 +42,10 @@ func (t *ListType) IsSameType(other Type) bool {
 	return false
 }
 
+func (t *ListType) TypeRequiredFeatures() FeatureSet {
+	return t.Type.TypeRequiredFeatures()
+}
+
 func (t *ListType) Unwrap() Type {
 	return t.Type
 }

--- a/graphql/schema/nonnull_type.go
+++ b/graphql/schema/nonnull_type.go
@@ -38,6 +38,10 @@ func (t *NonNullType) IsSameType(other Type) bool {
 	return false
 }
 
+func (t *NonNullType) TypeRequiredFeatures() FeatureSet {
+	return t.Type.TypeRequiredFeatures()
+}
+
 func (t *NonNullType) Unwrap() Type {
 	return t.Type
 }

--- a/graphql/schema/object_type.go
+++ b/graphql/schema/object_type.go
@@ -92,15 +92,19 @@ func (t *ObjectType) satisfyInterface(iface *InterfaceType) error {
 }
 
 func (t *ObjectType) shallowValidate() error {
-	if len(t.Fields) == 0 {
-		return fmt.Errorf("%v must have at least one field", t.Name)
-	}
+	hasAtLeastOneUnconditionalField := false
 	for name, field := range t.Fields {
 		if !isName(name) || strings.HasPrefix(name, "__") {
 			return fmt.Errorf("illegal field name: %v", name)
 		} else if !field.Type.IsOutputType() {
 			return fmt.Errorf("%v field must be an output type", name)
 		}
+		if len(field.RequiredFeatures) == 0 {
+			hasAtLeastOneUnconditionalField = true
+		}
+	}
+	if !hasAtLeastOneUnconditionalField {
+		return fmt.Errorf("%v must have at least one field", t.Name)
 	}
 	for _, iface := range t.ImplementedInterfaces {
 		if err := t.satisfyInterface(iface); err != nil {

--- a/graphql/schema/object_type.go
+++ b/graphql/schema/object_type.go
@@ -18,6 +18,13 @@ type ObjectType struct {
 	IsTypeOf func(obj interface{}) bool
 }
 
+func (t *ObjectType) GetField(name string, features FeatureSet) *FieldDefinition {
+	if field, ok := t.Fields[name]; ok && field.RequiredFeatures.IsSubsetOf(features) {
+		return field
+	}
+	return nil
+}
+
 func (t *ObjectType) String() string {
 	return t.Name
 }
@@ -64,6 +71,8 @@ func (t *ObjectType) satisfyInterface(iface *InterfaceType) error {
 			return fmt.Errorf("object is missing field named %v", name)
 		} else if !field.Type.IsSubTypeOf(ifaceField.Type) {
 			return fmt.Errorf("object's %v field is not a subtype of the corresponding interface field", name)
+		} else if !field.RequiredFeatures.IsSubsetOf(ifaceField.RequiredFeatures) {
+			return fmt.Errorf("object's %v field requires features that are not required by the corresponding interface field", name)
 		}
 		for argName, ifaceArg := range ifaceField.Arguments {
 			arg, ok := field.Arguments[argName]

--- a/graphql/schema/object_type.go
+++ b/graphql/schema/object_type.go
@@ -11,6 +11,9 @@ type ObjectType struct {
 	Directives  []*Directive
 	Fields      map[string]*FieldDefinition
 
+	// This type is only available for introspection and use when the given features are enabled.
+	RequiredFeatures FeatureSet
+
 	ImplementedInterfaces []*InterfaceType
 
 	// Objects that implement one or more interfaces must define this. The function should return
@@ -60,6 +63,10 @@ func (t *ObjectType) IsSameType(other Type) bool {
 	return t == other
 }
 
+func (t *ObjectType) TypeRequiredFeatures() FeatureSet {
+	return t.RequiredFeatures
+}
+
 func (t *ObjectType) TypeName() string {
 	return t.Name
 }
@@ -99,7 +106,7 @@ func (t *ObjectType) shallowValidate() error {
 		} else if !field.Type.IsOutputType() {
 			return fmt.Errorf("%v field must be an output type", name)
 		}
-		if len(field.RequiredFeatures) == 0 {
+		if field.RequiredFeatures.IsSubsetOf(t.RequiredFeatures) {
 			hasAtLeastOneUnconditionalField = true
 		}
 	}

--- a/graphql/schema/scalar_type.go
+++ b/graphql/schema/scalar_type.go
@@ -11,6 +11,9 @@ type ScalarType struct {
 	Description string
 	Directives  []*Directive
 
+	// This type is only available for introspection and use when the given features are enabled.
+	RequiredFeatures FeatureSet
+
 	// Should return nil if coercion is impossible.
 	LiteralCoercion func(ast.Value) interface{}
 
@@ -40,6 +43,10 @@ func (t *ScalarType) IsSubTypeOf(other Type) bool {
 
 func (t *ScalarType) IsSameType(other Type) bool {
 	return t == other
+}
+
+func (t *ScalarType) TypeRequiredFeatures() FeatureSet {
+	return t.RequiredFeatures
 }
 
 func (t *ScalarType) TypeName() string {

--- a/graphql/schema/schema.go
+++ b/graphql/schema/schema.go
@@ -142,6 +142,7 @@ type Type interface {
 	IsOutputType() bool
 	IsSubTypeOf(Type) bool
 	IsSameType(Type) bool
+	TypeRequiredFeatures() FeatureSet
 }
 
 type NamedType interface {

--- a/graphql/validator/coerce.go
+++ b/graphql/validator/coerce.go
@@ -5,11 +5,11 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema"
 )
 
-func CoerceVariableValues(s *schema.Schema, operation *ast.OperationDefinition, variableValues map[string]interface{}) (map[string]interface{}, *Error) {
+func CoerceVariableValues(s *schema.Schema, features schema.FeatureSet, operation *ast.OperationDefinition, variableValues map[string]interface{}) (map[string]interface{}, *Error) {
 	coercedValues := map[string]interface{}{}
 	for _, def := range operation.VariableDefinitions {
 		variableName := def.Variable.Name.Name
-		variableType := schemaType(def.Type, s)
+		variableType := schemaType(def.Type, s, features)
 		if variableType == nil || !variableType.IsInputType() {
 			return nil, newError(def.Type, "Invalid variable type.")
 		}

--- a/graphql/validator/type_info.go
+++ b/graphql/validator/type_info.go
@@ -41,7 +41,7 @@ func schemaType(t ast.Type, s *schema.Schema) schema.Type {
 	return nil
 }
 
-func NewTypeInfo(doc *ast.Document, s *schema.Schema) *TypeInfo {
+func NewTypeInfo(doc *ast.Document, s *schema.Schema, features schema.FeatureSet) *TypeInfo {
 	ret := &TypeInfo{
 		SelectionSetTypes:       map[*ast.SelectionSet]schema.NamedType{},
 		VariableDefinitionTypes: map[*ast.VariableDefinition]schema.Type{},
@@ -101,9 +101,9 @@ func NewTypeInfo(doc *ast.Document, s *schema.Schema) *TypeInfo {
 			var field *schema.FieldDefinition
 			switch parent := selectionSetScopes[len(selectionSetScopes)-1].(type) {
 			case *schema.InterfaceType:
-				field = parent.Fields[node.Name.Name]
+				field = parent.GetField(node.Name.Name, features)
 			case *schema.ObjectType:
-				field = parent.Fields[node.Name.Name]
+				field = parent.GetField(node.Name.Name, features)
 				if field == nil && parent == s.QueryType() {
 					field = introspection.MetaFields[node.Name.Name]
 				}

--- a/graphql/validator/validate_arguments.go
+++ b/graphql/validator/validate_arguments.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema"
 )
 
-func validateArguments(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateArguments(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	var ret []*Error
 	ast.Inspect(doc, func(node ast.Node) bool {
 		var arguments []*ast.Argument

--- a/graphql/validator/validate_cost.go
+++ b/graphql/validator/validate_cost.go
@@ -40,7 +40,7 @@ func checkedNonNegativeAdd(a, b int) int {
 // Queries with costs that are too high to calculate due to overflows always result in an error when
 // max is non-negative, and actual will be set to the maximum possible value.
 func ValidateCost(operationName string, variableValues map[string]interface{}, max int, actual *int, defaultCost schema.FieldCost) Rule {
-	return func(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*Error {
+	return func(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 		var ret []*Error
 
 		var op *ast.OperationDefinition

--- a/graphql/validator/validate_cost.go
+++ b/graphql/validator/validate_cost.go
@@ -65,7 +65,7 @@ func ValidateCost(operationName string, variableValues map[string]interface{}, m
 
 		var coercedVariableValues map[string]interface{}
 		if op != nil {
-			if v, err := CoerceVariableValues(s, op, variableValues); err != nil {
+			if v, err := CoerceVariableValues(s, features, op, variableValues); err != nil {
 				ret = append(ret, newSecondaryError(op, err.Error()))
 			} else {
 				coercedVariableValues = v

--- a/graphql/validator/validate_cost_test.go
+++ b/graphql/validator/validate_cost_test.go
@@ -117,7 +117,7 @@ func TestValidateCost(t *testing.T) {
 			require.NotNil(t, doc)
 
 			var cost int
-			errs := ValidateDocument(doc, s, ValidateCost(tc.OperationName, tc.VariableValues, tc.MaxCost, &cost, schema.FieldCost{Resolver: 1}))
+			errs := ValidateDocument(doc, s, nil, ValidateCost(tc.OperationName, tc.VariableValues, tc.MaxCost, &cost, schema.FieldCost{Resolver: 1}))
 			for _, err := range errs {
 				assert.NotEmpty(t, err.Message)
 				assert.NotEmpty(t, err.Locations)

--- a/graphql/validator/validate_directives.go
+++ b/graphql/validator/validate_directives.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema"
 )
 
-func validateDirectives(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateDirectives(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	var ret []*Error
 	ast.Inspect(doc, func(node ast.Node) bool {
 		var directives []*ast.Directive

--- a/graphql/validator/validate_document.go
+++ b/graphql/validator/validate_document.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema"
 )
 
-func validateDocument(doc *ast.Document, schema *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateDocument(doc *ast.Document, schema *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	var ret []*Error
 	for _, def := range doc.Definitions {
 		switch def.(type) {

--- a/graphql/validator/validate_fields.go
+++ b/graphql/validator/validate_fields.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema/introspection"
 )
 
-func validateFields(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateFields(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	var ret []*Error
 
 	fragmentDefinitions := map[string]*ast.FragmentDefinition{}
@@ -49,12 +49,12 @@ func validateFields(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*
 			if name != "__typename" {
 				switch parent := selectionSetTypes[len(selectionSetTypes)-1].(type) {
 				case *schema.ObjectType:
-					if _, ok := parent.Fields[name]; !ok && (parent != s.QueryType() || introspection.MetaFields[name] == nil) {
+					if parent.GetField(name, features) == nil && (parent != s.QueryType() || introspection.MetaFields[name] == nil) {
 						ret = append(ret, newError(node.Name, "field %v does not exist on %v", name, parent.Name))
 						fieldExists = false
 					}
 				case *schema.InterfaceType:
-					if _, ok := parent.Fields[name]; !ok {
+					if parent.GetField(name, features) == nil {
 						ret = append(ret, newError(node.Name, "field %v does not exist on %v", name, parent.Name))
 						fieldExists = false
 					}

--- a/graphql/validator/validate_fields_test.go
+++ b/graphql/validator/validate_fields_test.go
@@ -63,6 +63,20 @@ func TestFields_FieldSelectionMerging(t *testing.T) {
 	assert.Len(t, validateSource(t, `{objects:object{int} objects{int}}`), 1)
 }
 
+func TestFields_Features(t *testing.T) {
+	t.Run("FeatureDisabled", func(t *testing.T) {
+		assert.Empty(t, validateSource(t, `{pet{... on Cat{age}}}`))
+		assert.Len(t, validateSource(t, `{pet{... on Dog{age}}}`), 1)
+		assert.Len(t, validateSource(t, `{pet{age}}`), 1)
+	})
+
+	t.Run("FeatureEnabled", func(t *testing.T) {
+		assert.Empty(t, validateSource(t, `{pet{... on Cat{age}}}`, "petage"))
+		assert.Empty(t, validateSource(t, `{pet{... on Dog{age}}}`, "petage"))
+		assert.Empty(t, validateSource(t, `{pet{age}}`, "petage"))
+	})
+}
+
 func TestValuesAreIdentical(t *testing.T) {
 	for name, tc := range map[string]struct {
 		A1 ast.Value

--- a/graphql/validator/validate_fragments.go
+++ b/graphql/validator/validate_fragments.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema"
 )
 
-func validateFragments(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateFragments(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	ret := validateFragmentDeclarations(doc, s, typeInfo)
 	ret = append(ret, validateFragmentSpreads(doc, s, typeInfo)...)
 	return ret

--- a/graphql/validator/validate_fragments.go
+++ b/graphql/validator/validate_fragments.go
@@ -8,16 +8,16 @@ import (
 )
 
 func validateFragments(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
-	ret := validateFragmentDeclarations(doc, s, typeInfo)
-	ret = append(ret, validateFragmentSpreads(doc, s, typeInfo)...)
+	ret := validateFragmentDeclarations(doc, s, features, typeInfo)
+	ret = append(ret, validateFragmentSpreads(doc, s, features, typeInfo)...)
 	return ret
 }
 
-func validateFragmentDeclarations(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateFragmentDeclarations(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	var ret []*Error
 
 	validateTypeCondition := func(tc *ast.NamedType) {
-		switch namedType(s, tc.Name.Name).(type) {
+		switch namedType(s, features, tc.Name.Name).(type) {
 		case *schema.ObjectType, *schema.InterfaceType, *schema.UnionType:
 		case nil:
 			ret = append(ret, newError(tc.Name, "undefined type"))
@@ -60,7 +60,7 @@ func validateFragmentDeclarations(doc *ast.Document, s *schema.Schema, typeInfo 
 	return ret
 }
 
-func validateFragmentSpreads(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateFragmentSpreads(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	var ret []*Error
 
 	fragmentsByName := map[string]*ast.FragmentDefinition{}
@@ -106,7 +106,7 @@ func validateFragmentSpreads(doc *ast.Document, s *schema.Schema, typeInfo *Type
 			ret = append(ret, newSecondaryError(tc, "no type info for fragment spread parent"))
 			return
 		}
-		switch fragmentType := namedType(s, tc.Name.Name).(type) {
+		switch fragmentType := namedType(s, features, tc.Name.Name).(type) {
 		case *schema.ObjectType, *schema.InterfaceType, *schema.UnionType:
 			a := getPossibleTypes(s, fragmentType)
 			b := getPossibleTypes(s, parentType)

--- a/graphql/validator/validate_fragments_test.go
+++ b/graphql/validator/validate_fragments_test.go
@@ -66,4 +66,9 @@ func TestValidateFragmentSpreads(t *testing.T) {
 		assert.Empty(t, validateSource(t, `{union{... on UnionMember{... on Union{... on UnionObjectA{a}}}}}`))
 		assert.Len(t, validateSource(t, `{union{... on UnionMember{... on Node{id}}}}`), 1)
 	})
+
+	t.Run("Features", func(t *testing.T) {
+		assert.Empty(t, validateSource(t, `{experimentalObject{...a}} fragment a on ExperimentalObject { foo }`, "experimentalobject"))
+		assert.Len(t, validateSource(t, `{experimentalObject{...a}} fragment a on ExperimentalObject { foo }`), 2)
+	})
 }

--- a/graphql/validator/validate_operations.go
+++ b/graphql/validator/validate_operations.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema"
 )
 
-func validateOperations(doc *ast.Document, schema *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateOperations(doc *ast.Document, schema *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	var ret []*Error
 
 	anonymousOperationCount := 0

--- a/graphql/validator/validate_values.go
+++ b/graphql/validator/validate_values.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema"
 )
 
-func validateValues(doc *ast.Document, s *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateValues(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	var ret []*Error
 
 	ast.Inspect(doc, func(node ast.Node) bool {

--- a/graphql/validator/validate_variables.go
+++ b/graphql/validator/validate_variables.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ccbrown/api-fu/graphql/schema"
 )
 
-func validateVariables(doc *ast.Document, schema *schema.Schema, typeInfo *TypeInfo) []*Error {
+func validateVariables(doc *ast.Document, schema *schema.Schema, features schema.FeatureSet, typeInfo *TypeInfo) []*Error {
 	fragmentDefinitions := map[string]*ast.FragmentDefinition{}
 	for _, def := range doc.Definitions {
 		if def, ok := def.(*ast.FragmentDefinition); ok {

--- a/graphql/validator/validator.go
+++ b/graphql/validator/validator.go
@@ -62,10 +62,10 @@ func newSecondaryError(node ast.Node, message string, args ...interface{}) *Erro
 	}
 }
 
-type Rule func(*ast.Document, *schema.Schema, *TypeInfo) []*Error
+type Rule func(*ast.Document, *schema.Schema, schema.FeatureSet, *TypeInfo) []*Error
 
-func ValidateDocument(doc *ast.Document, s *schema.Schema, additionalRules ...Rule) []*Error {
-	typeInfo := NewTypeInfo(doc, s)
+func ValidateDocument(doc *ast.Document, s *schema.Schema, features schema.FeatureSet, additionalRules ...Rule) []*Error {
+	typeInfo := NewTypeInfo(doc, s, features)
 	var errs []*Error
 	for _, f := range append([]Rule{
 		validateDocument,
@@ -77,7 +77,7 @@ func ValidateDocument(doc *ast.Document, s *schema.Schema, additionalRules ...Ru
 		validateDirectives,
 		validateVariables,
 	}, additionalRules...) {
-		errs = append(errs, f(doc, s, typeInfo)...)
+		errs = append(errs, f(doc, s, features, typeInfo)...)
 	}
 	var primary []*Error
 	for _, err := range errs {

--- a/graphql/validator/validator_test.go
+++ b/graphql/validator/validator_test.go
@@ -47,6 +47,16 @@ var objectType = &schema.ObjectType{
 	Name: "Object",
 }
 
+var experimentalObjectType = &schema.ObjectType{
+	Name:             "ExperimentalObject",
+	RequiredFeatures: schema.NewFeatureSet("experimentalobject"),
+	Fields: map[string]*schema.FieldDefinition{
+		"foo": {
+			Type: schema.BooleanType,
+		},
+	},
+}
+
 var complexInputType = &schema.InputObjectType{
 	Name: "ComplexInput",
 	Fields: map[string]*schema.InputValueDefinition{
@@ -91,6 +101,10 @@ func init() {
 		"freeBoolean": {
 			Type: schema.BooleanType,
 			Cost: schema.FieldResolverCost(0),
+		},
+		"experimentalObject": {
+			Type:             experimentalObjectType,
+			RequiredFeatures: schema.NewFeatureSet("experimentalobject"),
 		},
 		"booleanArgField": {
 			Type: schema.BooleanType,

--- a/graphql/validator/validator_test.go
+++ b/graphql/validator/validator_test.go
@@ -18,6 +18,10 @@ var petType = &schema.InterfaceType{
 		"nickname": {
 			Type: schema.StringType,
 		},
+		"age": {
+			Type:             schema.IntType,
+			RequiredFeatures: schema.NewFeatureSet("petage"),
+		},
 	},
 }
 
@@ -60,6 +64,10 @@ var dogType = &schema.ObjectType{
 		},
 		"barkVolume": {
 			Type: schema.IntType,
+		},
+		"age": {
+			Type:             schema.IntType,
+			RequiredFeatures: schema.NewFeatureSet("petage"),
 		},
 	},
 	ImplementedInterfaces: []*schema.InterfaceType{petType},
@@ -162,6 +170,9 @@ func init() {
 						Type: schema.StringType,
 					},
 					"meowVolume": {
+						Type: schema.IntType,
+					},
+					"age": {
 						Type: schema.IntType,
 					},
 				},
@@ -328,7 +339,7 @@ func init() {
 	}
 }
 
-func validateSource(t *testing.T, src string) []*Error {
+func validateSource(t *testing.T, src string, features ...string) []*Error {
 	s, err := schema.New(&schema.SchemaDefinition{
 		Query:        objectType,
 		Subscription: objectType,
@@ -338,15 +349,15 @@ func validateSource(t *testing.T, src string) []*Error {
 		},
 	})
 	require.NoError(t, err)
-	return validateSourceWithSchema(t, s, src)
+	return validateSourceWithSchema(t, s, src, features...)
 }
 
-func validateSourceWithSchema(t *testing.T, s *schema.Schema, src string) []*Error {
+func validateSourceWithSchema(t *testing.T, s *schema.Schema, src string, features ...string) []*Error {
 	doc, parseErrs := parser.ParseDocument([]byte(src))
 	require.Empty(t, parseErrs)
 	require.NotNil(t, doc)
 
-	errs := ValidateDocument(doc, s, nil)
+	errs := ValidateDocument(doc, s, schema.NewFeatureSet(features...))
 	for _, err := range errs {
 		assert.NotEmpty(t, err.Message)
 		assert.NotEmpty(t, err.Locations)

--- a/graphql/validator/validator_test.go
+++ b/graphql/validator/validator_test.go
@@ -346,7 +346,7 @@ func validateSourceWithSchema(t *testing.T, s *schema.Schema, src string) []*Err
 	require.Empty(t, parseErrs)
 	require.NotNil(t, doc)
 
-	errs := ValidateDocument(doc, s)
+	errs := ValidateDocument(doc, s, nil)
 	for _, err := range errs {
 		assert.NotEmpty(t, err.Message)
 		assert.NotEmpty(t, err.Locations)

--- a/graphqlws.go
+++ b/graphqlws.go
@@ -60,6 +60,7 @@ func (h *graphqlWSHandler) HandleStart(id string, query string, variables map[st
 		Query:          query,
 		Schema:         h.API.schema,
 		IdleHandler:    apiRequest.IdleHandler,
+		Features:       h.features,
 		OperationName:  operationName,
 		VariableValues: variables,
 	}

--- a/graphqlws.go
+++ b/graphqlws.go
@@ -32,6 +32,7 @@ type graphqlWSHandler struct {
 
 	cancelContext func()
 	subscriptions map[string]*SubscriptionSourceStream
+	features      graphql.FeatureSet
 }
 
 func (h *graphqlWSHandler) HandleInit(parameters json.RawMessage) error {
@@ -41,6 +42,9 @@ func (h *graphqlWSHandler) HandleInit(parameters json.RawMessage) error {
 		} else {
 			h.Context = ctx
 		}
+	}
+	if h.API.config.Features != nil {
+		h.features = h.API.config.Features(h.Context)
 	}
 	return nil
 }
@@ -62,7 +66,7 @@ func (h *graphqlWSHandler) HandleStart(id string, query string, variables map[st
 
 	var info RequestInfo
 	var resp *graphql.Response
-	if doc, errs := graphql.ParseAndValidate(req.Query, req.Schema, req.ValidateCost(-1, &info.Cost, h.API.config.DefaultFieldCost)); len(errs) > 0 {
+	if doc, errs := graphql.ParseAndValidate(req.Query, req.Schema, req.Features, req.ValidateCost(-1, &info.Cost, h.API.config.DefaultFieldCost)); len(errs) > 0 {
 		resp = &graphql.Response{
 			Errors: errs,
 		}

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -86,7 +86,7 @@ func TestConnection(t *testing.T) {
 			}
 			totalCount
 		}
-	`, api.schema, graphql.ValidateCost("", nil, -1, &cost, graphql.FieldCost{Resolver: 1}))
+	`, api.schema, nil, graphql.ValidateCost("", nil, -1, &cost, graphql.FieldCost{Resolver: 1}))
 		require.Empty(t, errs)
 		assert.Equal(t, (1 /*connection*/)+(10 /* edges */)*(1 /* node */)+(1 /*totalCount*/), cost)
 	})


### PR DESCRIPTION
## What it Does

This adds an API for specifying a set of required features for types and object and interface fields.

The set of enabled features is given as a parameter to GraphQL validation and execution.

Types and fields that require features which are not enabled effectively do not exist – queries containing them will not validate and they will not appear in introspection.

At schema compilation time, a set of rules is used to ensure that all possible combinations of enabled feature flags result in a perfectly valid schema:

- Fields on interface implementations must require a subset of the features required by the corresponding interface field.
- Objects and interfaces must always contain at least one field whose feature requirements are a subset of their own.
- Field types must never require features that aren't required by the field itself.
- Field argument types must never require features that aren't required by the field itself.

This functionality is closely related to the proposal in [the GraphQL RFC for Opt-in features](https://github.com/graphql/graphql-wg/blob/f3fa75bc36e91ab8036fdf2350a3baddd00045f2/rfcs/OptInFeatures.md) and discussion happening in https://github.com/graphql/graphql-spec/issues/943.

### Limitations:

This PR doesn't support:

- Union members which require features not required by the union.
- Feature flagged input object fields.
- Feature flagged field arguments.
- Feature flagged enum values.

These may be added in a future PR.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
