### PR TITLE
fix panic when node id is an int

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -163,14 +163,18 @@ func TestNodes(t *testing.T) {
 			c: node(id: "c") {
 				id
 			}
+			one: node(id: 1) {
+				id
+			}
 		}`)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		var result struct {
 			Data struct {
-				A *node
-				C *node
+				A   *node
+				C   *node
+				One *node
 			}
 			Errors []struct{}
 		}
@@ -179,11 +183,12 @@ func TestNodes(t *testing.T) {
 
 		assert.NotNil(t, result.Data.A)
 		assert.Nil(t, result.Data.C)
+		assert.Nil(t, result.Data.One)
 	})
 
 	t.Run("Multiple", func(t *testing.T) {
 		resp := executeGraphQL(t, api, `{
-			nodes(ids: ["a", "b", "c", "d"]) {
+			nodes(ids: ["a", "b", "c", "d", 1]) {
 				id
 			}
 		}`)

--- a/config.go
+++ b/config.go
@@ -92,11 +92,15 @@ func (cfg *Config) init() {
 					Cost: graphql.FieldResolverCost(1),
 					Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 						// TODO: batching?
-						nodes, err := ctxAPI(ctx.Context).config.ResolveNodesByGlobalIds(ctx.Context, []string{ctx.Arguments["id"].(string)})
-						if err != nil || len(nodes) == 0 {
-							return nil, err
+						if id, ok := ctx.Arguments["id"].(string); ok {
+							nodes, err := ctxAPI(ctx.Context).config.ResolveNodesByGlobalIds(ctx.Context, []string{id})
+							if err != nil || len(nodes) == 0 {
+								return nil, err
+							}
+							return nodes[0], nil
+						} else {
+							return nil, nil
 						}
-						return nodes[0], nil
 					},
 				},
 				"nodes": {
@@ -117,7 +121,9 @@ func (cfg *Config) init() {
 					Resolve: func(ctx graphql.FieldContext) (interface{}, error) {
 						var ids []string
 						for _, id := range ctx.Arguments["ids"].([]interface{}) {
-							ids = append(ids, id.(string))
+							if id, ok := id.(string); ok {
+								ids = append(ids, id)
+							}
 						}
 						return ctxAPI(ctx.Context).config.ResolveNodesByGlobalIds(ctx.Context, ids)
 					},


### PR DESCRIPTION
## What it Does

Fixes a panic in the `node` resolver when a non-string id is given (which isn't currently supported).

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
