### PR TITLE
ensure that we always send a "complete" message when subscription streams end

### DIFF
--- a/graphql/transport/graphqltransportws/connection.go
+++ b/graphql/transport/graphqltransportws/connection.go
@@ -188,12 +188,6 @@ func (c *Connection) handleMessage(ctx context.Context, data []byte) {
 		}
 
 		c.Handler.HandleStop(msg.Id)
-		if err := c.sendMessage(context.Background(), &Message{
-			Id:   msg.Id,
-			Type: MessageTypeComplete,
-		}); err != nil {
-			c.Handler.LogError(errors.Wrap(err, "unable to send graphql-transport-ws complete response"))
-		}
 	case MessageTypePong:
 		// do nothing
 	default:

--- a/graphql/transport/graphqlws/connection.go
+++ b/graphql/transport/graphqlws/connection.go
@@ -208,12 +208,6 @@ func (c *Connection) handleMessage(ctx context.Context, data []byte) {
 		}
 
 		c.Handler.HandleStop(msg.Id)
-		if err := c.sendMessage(context.Background(), &Message{
-			Id:   msg.Id,
-			Type: MessageTypeComplete,
-		}); err != nil {
-			c.Handler.LogError(errors.Wrap(err, "unable to send graphql-ws stop response"))
-		}
 	case MessageTypeConnectionTerminate:
 		c.beginClosing(websocket.CloseNormalClosure, "terminate requested by client")
 	default:

--- a/graphqlws.go
+++ b/graphqlws.go
@@ -102,6 +102,9 @@ func (h *graphqlWSHandler) HandleStart(id string, query string, variables map[st
 					}); err != nil && err != context.Canceled {
 						h.Logger.Error(errors.Wrap(err, "error running source stream"))
 					}
+					if err := h.Connection.SendComplete(context.Background(), id); err != nil {
+						h.Logger.Warn(errors.Wrap(err, "error sending graphql-ws complete"))
+					}
 				}()
 			}
 		} else {

--- a/subscription.go
+++ b/subscription.go
@@ -8,7 +8,7 @@ import (
 // SubscriptionSourceStream defines the source stream for a subscription.
 type SubscriptionSourceStream struct {
 	// A channel of events. The channel can be of any type.
-	EventChannel interface{}
+	EventChannel any
 
 	// Stop is invoked when the subscription should be stopped and the event channel should be
 	// closed.


### PR DESCRIPTION
## What it Does

Ensures that we always send a "complete" message when subscription streams end. I.e. we shouldn't assume that subscriptions last until canceled.

This also fixes a goroutine leak when stream `Stop` methods don't close the stream event channel (as is the case with the tickers used in tests).

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
