### PR TITLE
don't log error when WS client initiates close

### DIFF
--- a/graphql/transport/graphqltransportws/connection.go
+++ b/graphql/transport/graphqltransportws/connection.go
@@ -258,9 +258,7 @@ func (c *Connection) writeLoop() {
 			return
 		case <-c.closeReceived:
 			// the client initiated the close handshake
-			if err := c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "close requested by client")); err != nil {
-				c.Handler.LogError(errors.Wrap(err, "websocket control write error"))
-			}
+			c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "close requested by client"))
 			return
 		}
 

--- a/graphql/transport/graphqlws/connection.go
+++ b/graphql/transport/graphqlws/connection.go
@@ -278,9 +278,7 @@ func (c *Connection) writeLoop() {
 			return
 		case <-c.closeReceived:
 			// the client initiated the close handshake
-			if err := c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "close requested by client")); err != nil {
-				c.Handler.LogError(errors.Wrap(err, "websocket control write error"))
-			}
+			c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "close requested by client"))
 			return
 		}
 


### PR DESCRIPTION
## What it Does

Kills these noisy error logs in the case where the client is closing the connection

## Steps to Test

`go test -v ./...`