### PR TITLE
fix for async errors being returned multiple times

### DIFF
--- a/graphql/executor/internal/future/future.go
+++ b/graphql/executor/internal/future/future.go
@@ -223,7 +223,8 @@ func Join[T any](fs ...Future[T]) Future[[]T] {
 	return New(func() (Result[[]T], bool) {
 		ok := true
 
-		for i, f := range fs {
+		for i := range fs {
+			f := &fs[i]
 			f.Poll()
 			if f.IsReady() {
 				if !f.Result().IsOk() {


### PR DESCRIPTION
## What it Does

This fixes a bug where an error returned by an asynchronous resolver could be duplicated in the response multiple times.

## Steps to Test

<!-- All changes should have automated tests when feasible: -->

`go test -v ./...`

<!-- Does running this require any special setup or dependencies? -->
